### PR TITLE
Enable proxy auth

### DIFF
--- a/jobs/opensearch/spec
+++ b/jobs/opensearch/spec
@@ -62,6 +62,9 @@ properties:
   opensearch.cluster_name:
     description: The name of the open search cluster
     default: "opensearch"
+  opensearch.enable_proxy_auth:
+    description: "Enable proxy-based authentication for login to Opensearch"
+    default: false
   opensearch.log_level:
     description: The default logging level (e.g. WARN, DEBUG, INFO)
     default: INFO

--- a/jobs/opensearch/spec
+++ b/jobs/opensearch/spec
@@ -50,6 +50,8 @@ consumes:
 - name: opensearch
   type: opensearch
   optional: true
+- name: opensearch_dashboards
+  type: opensearch_dashboards
 
 properties:
   opensearch.username:

--- a/jobs/opensearch/templates/config/opensearch-security/config.yml.erb
+++ b/jobs/opensearch/templates/config/opensearch-security/config.yml.erb
@@ -5,6 +5,13 @@ _meta:
 
 config:
   dynamic:
+    <% if_p('opensearch.enable_proxy_auth') do %>
+    http:
+      xff:
+        enabled: true
+        internalProxies: '<%= link('opensearch_dashboards').instances[0].address %>'
+        remoteIpHeader: "x-forwarded-for"
+    <% end %>
     authc:
       clientcert_auth_domain:
         description: "Authenticate via SSL client certificates"

--- a/jobs/opensearch/templates/config/opensearch-security/config.yml.erb
+++ b/jobs/opensearch/templates/config/opensearch-security/config.yml.erb
@@ -18,6 +18,7 @@ config:
           challenge: false
         authentication_backend:
           type: noop
+      <% if_p('opensearch.enable_proxy_auth') do %>
       proxy_auth_domain:
         http_enabled: true
         transport_enabled: true
@@ -31,3 +32,4 @@ config:
             attr_header_prefix: "x-proxy-ext-"
         authentication_backend:
           type: noop
+      <% end %>

--- a/jobs/opensearch/templates/config/opensearch-security/config.yml.erb
+++ b/jobs/opensearch/templates/config/opensearch-security/config.yml.erb
@@ -18,3 +18,16 @@ config:
           challenge: false
         authentication_backend:
           type: noop
+      proxy_auth_domain:
+        http_enabled: true
+        transport_enabled: true
+        order: 0
+        http_authenticator:
+          type: extended-proxy
+          challenge: false
+          config:
+            user_header: "x-proxy-user"
+            roles_header: "x-proxy-roles"
+            attr_header_prefix: "x-proxy-ext-"
+        authentication_backend:
+          type: noop

--- a/jobs/opensearch_dashboards/spec
+++ b/jobs/opensearch_dashboards/spec
@@ -45,6 +45,9 @@ properties:
   opensearch_dashboards.opensearch.ssl.verification_mode:
     description: "Verification mode to use when connecting from Opensearch Dashboards to Opensearch"
     default: "full"
+  opensearch_dashboards.opensearch.enable_proxy_auth:
+    description: "Enable proxy-based authentication for login to Opensearch Dashboards"
+    default: false
   opensearch_dashboards.defaultAppId:
     description: "The default application to load."
     default: "discover"

--- a/jobs/opensearch_dashboards/templates/config/opensearch_dashboards.conf.erb
+++ b/jobs/opensearch_dashboards/templates/config/opensearch_dashboards.conf.erb
@@ -71,6 +71,13 @@ opensearch.requestTimeout: <%= p('opensearch_dashboards.request_timeout') %>
 # opensearch.shardTimeout: 0
 opensearch.shardTimeout: <%= p('opensearch_dashboards.shard_timeout') %>
 
+<% if_p('opensearch_dashboards.opensearch.enable_proxy_auth') do %>
+opensearch.requestHeadersAllowlist: ["securitytenant","Authorization","x-forwarded-for","x-proxy-user","x-proxy-roles","x-proxy-ext-spaceids","x-proxy-ext-orgids"]
+opensearch_security.auth.type: "proxy"
+opensearch_security.proxycache.user_header: "x-proxy-user"
+opensearch_security.proxycache.roles_header: "x-proxy-roles"
+<% end %>
+
 <% if_p('opensearch_dashboards.config_options') do p("opensearch_dashboards.config_options", {}).each do | k, v | %>
 <%= k %>: <%= v %><% end %>
 <% end %>


### PR DESCRIPTION
## Changes proposed in this pull request:

Based on https://opensearch.org/docs/latest/security/authentication-backends/proxy/, add the configuration necessary to support proxy-based authentication to Opensearch

- Add configuration for Opensearch security plugin to enable proxy-based authentication. Must set `opensearch.enable_proxy_auth` property for the job for configuration to appear
  - Add IP for Opensearch Dashboards as the only trusted internal proxy IP 
- Add configuration for Opensearch dashboard to enable proxy-based authentication. Must set `opensearch_dashboards.opensearch.enable_proxy_auth` property for the job for configuration to appear

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

We are adding proxy-based authentication support to this BOSH release. Using a proxy allows us to easily translate a user's identity in UAA/CloudFoundry to a set of permissions that they should have in Opensearch. Combined with Opensearch's [document-level security](https://opensearch.org/docs/latest/security/access-control/document-level-security/) features, this authentication method should give us strong guarantees around our multi-tenancy protections and ensure that users only see the logs that they should.

The actual proxy is implemented/maintained here:

https://github.com/cloud-gov/opensearch-dashboards-cf-auth-proxy

The proxy itself contains unit and e2e tests to verify that users can only see the expected documents.
