### PR TITLE
Internal proxy fix

### DIFF
--- a/jobs/opensearch/spec
+++ b/jobs/opensearch/spec
@@ -50,8 +50,6 @@ consumes:
 - name: opensearch
   type: opensearch
   optional: true
-- name: opensearch_dashboards
-  type: opensearch_dashboards
 
 properties:
   opensearch.username:

--- a/jobs/opensearch/templates/config/opensearch-security/config.yml.erb
+++ b/jobs/opensearch/templates/config/opensearch-security/config.yml.erb
@@ -9,7 +9,7 @@ config:
     http:
       xff:
         enabled: true
-        internalProxies: '52\.222\.122\.*|52\.222\.123.*'
+        internalProxies: ".*"
         remoteIpHeader: "x-forwarded-for"
     <% end %>
     authc:

--- a/jobs/opensearch/templates/config/opensearch-security/config.yml.erb
+++ b/jobs/opensearch/templates/config/opensearch-security/config.yml.erb
@@ -9,7 +9,7 @@ config:
     http:
       xff:
         enabled: true
-        internalProxies: "127\.0\.0\.1"
+        internalProxies: "127.0.0.1"
         remoteIpHeader: "x-forwarded-for"
     <% end %>
     authc:

--- a/jobs/opensearch/templates/config/opensearch-security/config.yml.erb
+++ b/jobs/opensearch/templates/config/opensearch-security/config.yml.erb
@@ -9,7 +9,7 @@ config:
     http:
       xff:
         enabled: true
-        internalProxies: '<%= link('opensearch_dashboards').instances[0].address %>'
+        internalProxies: '52\.222\.122\.*|52\.222\.123.*'
         remoteIpHeader: "x-forwarded-for"
     <% end %>
     authc:

--- a/jobs/opensearch/templates/config/opensearch-security/config.yml.erb
+++ b/jobs/opensearch/templates/config/opensearch-security/config.yml.erb
@@ -9,7 +9,7 @@ config:
     http:
       xff:
         enabled: true
-        internalProxies: ".*"
+        internalProxies: "127\.0\.0\.1"
         remoteIpHeader: "x-forwarded-for"
     <% end %>
     authc:


### PR DESCRIPTION
## Changes proposed in this pull request:

Update Opensearch to only allow internal proxies from 127.0.0.1. See https://opensearch.org/docs/latest/security/authentication-backends/proxy/ for more information about proxy configuration.

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

These changes ensure that only a proxy identified as coming from `127.0.0.1` via `x-forwarded-for` header will be trusted for authentication
