### PR TITLE
fix opensearch security config unit tests

### DIFF
--- a/spec/jobs/opensearch_security_spec.rb
+++ b/spec/jobs/opensearch_security_spec.rb
@@ -35,15 +35,6 @@ describe 'opensearch job' do
     end
 
     describe 'with proxy auth settings' do
-      let(:link) do
-        Bosh::Template::Test::Link.new(
-          name: 'opensearch_dashboards',
-          instances: [
-            Bosh::Template::Test::LinkInstance.new(address: 'dashboard-1'),
-          ],
-        )
-      end
-
       let(:manifest) do
         {
           'opensearch' => {
@@ -53,14 +44,14 @@ describe 'opensearch job' do
       end
   
       let(:config) do
-        config = YAML.load(template.render(manifest, consumes: [link]))
+        config = YAML.load(template.render(manifest))
       end
 
       it 'configures http settings' do
         http_xff_config = config['config']['dynamic']['http']['xff']
         expect(http_xff_config).to eq({
           "enabled" => true,
-          "internalProxies" => "dashboard-1",
+          "internalProxies" => "127.0.0.1",
           "remoteIpHeader" => "x-forwarded-for",
         })
       end


### PR DESCRIPTION
## Changes proposed in this pull request:

- fix opensearch security config unit tests to have correct expectation for allowed internal proxy IPs

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None
