### PR TITLE
add CF user role and mapping

### DIFF
--- a/jobs/opensearch/templates/config/opensearch-security/roles.yml.erb
+++ b/jobs/opensearch/templates/config/opensearch-security/roles.yml.erb
@@ -362,3 +362,20 @@ security_analytics_ack_alerts:
   reserved: true
   cluster_permissions:
     - 'cluster:admin/opensearch/securityanalytics/alerts/*'
+
+cf_user:
+  reserved: false
+  hidden: false
+  cluster_permissions:
+  - "read"
+  - "cluster:monitor/nodes/stats"
+  - "cluster:monitor/task/get"
+  index_permissions:
+  - index_patterns:
+    - "logs-app-*"
+    dls: "{\"bool\": {\"should\": [{\"terms\": { \"@cf.space_id\": [${attr.proxy.spaceids}] }}, {\"terms\": {\"@cf.org_id\": [${attr.proxy.orgids}]}}]}}"
+    fls:
+    allowed_actions:
+    - "read"
+  tenant_permissions: []
+  static: false

--- a/jobs/opensearch/templates/config/opensearch-security/roles_mapping.yml.erb
+++ b/jobs/opensearch/templates/config/opensearch-security/roles_mapping.yml.erb
@@ -40,7 +40,18 @@ kibana_user:
   reserved: false
   backend_roles:
   - "kibanauser"
+  - "user"
   description: "Maps kibanauser to kibana_user"
+
+cf_user:
+  reserved: true
+  hidden: false
+  backend_roles:
+  - "user"
+  hosts: []
+  users: []
+  and_backend_roles: []
+  description: "CF users with privileges to their own spaces"
 
 readall:
   reserved: false


### PR DESCRIPTION
## Changes proposed in this pull request:

Related to https://github.com/cloud-gov/private/issues/800

- Add the `cf_user` role which will use [Opensearch document-level security](https://opensearch.org/docs/latest/security/access-control/document-level-security/) to restrict non-admin users to only see logs for the CF orgs and spaces
- Add role mapping from the `user` backend role to the `cf_user` role. The `user` backend role will be added for users by the [authentication proxy](https://github.com/cloud-gov/opensearch-dashboards-cf-auth-proxy)

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

These changes, in concert with the [authentication proxy](https://github.com/cloud-gov/opensearch-dashboards-cf-auth-proxy) which determines whether a user is an admin or regular CF user, will enforce access control so that non-admin users can only see logs for their CF orgs/spaces. These changes are an essential piece of verifying the multi-tenant isolation for the logs system.
