### PR TITLE
use fips endpoint for blobstore

### DIFF
--- a/config/final.yml
+++ b/config/final.yml
@@ -4,4 +4,5 @@ blobstore:
   options:
     bucket_name: cloud-gov-release-blobstore
     region: us-gov-west-1
+    host: s3-fips.us-gov-west-1.amazonaws.com
 final_name: opensearch


### PR DESCRIPTION
## Changes Proposed

- Set the host property to the fips endpoint

## Security Considerations

Instructs bosh to use the fips 140 compliant fips endpoint when interacting with S3.
