### PR TITLE
Update multitenancy config for OpenSearch Dashboards

### DIFF
--- a/jobs/opensearch_dashboards/spec
+++ b/jobs/opensearch_dashboards/spec
@@ -19,17 +19,17 @@ templates:
   config/ca.erb: config/ssl/opensearch.ca
 
 consumes:
-- name: opensearch
-  type: opensearch
-  optional: true
+  - name: opensearch
+    type: opensearch
+    optional: true
 
 provides:
-- name: opensearch_dashboards
-  type: opensearch_dashboards
-  properties:
-  - opensearch_dashboards.port
-  - opensearch_dashboards.server.ssl.certificate
-  - opensearch_dashboards.server.ssl.private_key
+  - name: opensearch_dashboards
+    type: opensearch_dashboards
+    properties:
+      - opensearch_dashboards.port
+      - opensearch_dashboards.server.ssl.certificate
+      - opensearch_dashboards.server.ssl.private_key
 
 properties:
   opensearch_dashboards.username:
@@ -101,3 +101,15 @@ properties:
   opensearch_dashboards.health.timeout:
     description: opensearch_dashboards health check number of attempts (seconds)
     default: 300
+  opensearch_dashboards.multitenancy.enabled:
+    description: "whether multitenancy is enabled for OpenSearch Dashboards"
+    default: true
+  opensearch_dashboards.multitenancy.enable_filter:
+    description: "whether a search bar appears for searching enabled tenants"
+    default: true
+  opensearch_dashboards.multitenancy.tenants.enable_global:
+    description: "whether the global tenant is available on OpenSearch Dashboards"
+    default: false
+  opensearch_dashboards.multitenancy.tenants.enable_private:
+    description: "whether the private tenant is available on OpenSearch Dashboards"
+    default: false

--- a/jobs/opensearch_dashboards/templates/config/opensearch_dashboards.conf.erb
+++ b/jobs/opensearch_dashboards/templates/config/opensearch_dashboards.conf.erb
@@ -93,10 +93,10 @@ opensearch_security.proxycache.user_header: "x-proxy-user"
 opensearch_security.proxycache.roles_header: "x-proxy-roles"
 <% end %>
 
-opensearch_security.multitenancy.enabled: true
-opensearch_security.multitenancy.tenants.enable_global: false
-opensearch_security.multitenancy.tenants.enable_private: true
-opensearch_security.multitenancy.enable_filter: false
+opensearch_security.multitenancy.enabled: <%= p('opensearch_dashboards.multitenancy.enabled') %>
+opensearch_security.multitenancy.tenants.enable_global: <%= p('opensearch_dashboards.multitenancy.tenants.enable_global') %>
+opensearch_security.multitenancy.tenants.enable_private: <%= p('opensearch_dashboards.multitenancy.tenants.enable_private') %>
+opensearch_security.multitenancy.enable_filter: <%= p('opensearch_dashboards.multitenancy.enable_filter') %>
 
 <% if_p('opensearch_dashboards.config_options') do p("opensearch_dashboards.config_options", {}).each do | k, v | %>
 <%= k %>: <%= v %><% end %>


### PR DESCRIPTION
## Changes proposed in this pull request:

- add more properties to opensearch_dashboards job spec for multitenancy
- set default for `opensearch_security.multitenancy.tenants.enable_private` to `false`

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just changing multitenancy configuration for OpenSearch Dashboards
