### PR TITLE
disable private tenant

### DIFF
--- a/jobs/opensearch/spec
+++ b/jobs/opensearch/spec
@@ -29,28 +29,28 @@ templates:
   config/opensearch-security/roles.yml.erb: config/opensearch-security/roles.yml
   config/opensearch-security/config.yml.erb: config/opensearch-security/config.yml
   config/opensearch-security/roles_mapping.yml.erb: config/opensearch-security/roles_mapping.yml
-  config/opensearch-notifications/notifications.erb : config/opensearch-notifications/notifications.yml
-  config/opensearch-notifications-core/notifications-core.erb : config/opensearch-notifications-core/notifications-core.yml
+  config/opensearch-notifications/notifications.erb: config/opensearch-notifications/notifications.yml
+  config/opensearch-notifications-core/notifications-core.erb: config/opensearch-notifications-core/notifications-core.yml
   config/opensearch-observability/observability.erb: config/opensearch-observability/observability.yml
   config/opensearch-reports-scheduler/reports-scheduler.erb: config/opensearch-reports-scheduler/reports-scheduler.yml
 
 provides:
-- name: opensearch
-  type: opensearch
-  properties:
-  - opensearch.port
-  - opensearch.cluster_name
-  - opensearch.admin.certificate
-  - opensearch.admin.private_key
-  - opensearch.node.ssl.ca
-  - opensearch.node.ssl.certificate
-  - opensearch.node.ssl.private_key
-  - opensearch.dashboard_username
+  - name: opensearch
+    type: opensearch
+    properties:
+      - opensearch.port
+      - opensearch.cluster_name
+      - opensearch.admin.certificate
+      - opensearch.admin.private_key
+      - opensearch.node.ssl.ca
+      - opensearch.node.ssl.certificate
+      - opensearch.node.ssl.private_key
+      - opensearch.dashboard_username
 
 consumes:
-- name: opensearch
-  type: opensearch
-  optional: true
+  - name: opensearch
+    type: opensearch
+    optional: true
 
 properties:
   opensearch.username:
@@ -83,7 +83,7 @@ properties:
       In order to register the shared file system repository it is
       necessary to mount the same shared filesystem to the same location
       on all manager and data nodes.
-    default: ''
+    default: ""
   opensearch.manager_hosts:
     description: Manually specify the host names for the manager nodes
     default: []
@@ -174,13 +174,16 @@ properties:
     default: 50s
   opensearch.repository.s3.bucket:
     description: Bucket name on S3 where to keep snapshots
-    default: ''
+    default: ""
   opensearch.repository.name:
     description: Repository name for automatic snapshots
-    default: ''
+    default: ""
   opensearch.discovery.single_node:
     description: True to run cluster as a single node
     default: false
   opensearch.dashboard_username:
     description: username for dashboard
     default: "dashboard.opensearch.internal"
+  opensearch.multitenancy.private_tenant_enabled:
+    description: True to enable private tenant
+    default: false

--- a/jobs/opensearch/templates/config/opensearch-security/config.yml.erb
+++ b/jobs/opensearch/templates/config/opensearch-security/config.yml.erb
@@ -7,6 +7,7 @@ config:
   dynamic:
     kibana:
       multitenancy_enabled: true
+      private_tenant_enabled: <%= p('opensearch.multitenancy.private_tenant_enabled') %>
       default_tenant: ""
       server_username: <%= p('opensearch.dashboard_username') %>
       index: <%= p('opensearch.index') %>


### PR DESCRIPTION
## Changes proposed in this pull request:

- add `opensearch.multitenancy.private_tenant_enabled` property to opensearch job spec 
- set default for `opensearch.multitenancy.private_tenant_enabled` to `false` so that private tenant will be disabled

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Disabling the private tenant will force users to use a tenant for their organization, meaning saved objects (visualizations, dashboards) will be visible to other users in their orgs
