### PR TITLE
Update database log filters

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,6 +96,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-21
+  x86_64-darwin-23
   x86_64-linux
 
 DEPENDENCIES

--- a/jobs/ingestor_cloudwatch/templates/config/input_and_output.conf.erb
+++ b/jobs/ingestor_cloudwatch/templates/config/input_and_output.conf.erb
@@ -18,6 +18,7 @@ filter
         rename => {"[cloudwatch_logs][tags][environment]"=>"environment"}
         rename => {"[cloudwatch_logs][tags][OrganizationGUID]"=>"[@cf][org_id]"}
         rename => {"[cloudwatch_logs][tags][SpaceGUID]"=>"[@cf][space_id]"}
+        rename => {"[cloudwatch_logs][tags][Spacename]"=>"[@cf][space]"}
         rename => {"[cloudwatch_logs][tags][Organizationname]"=>"[@cf][org]"}
         remove_field => ["[cloudwatch_logs][tags][Createdat]"]
         remove_field => ["[cloudwatch_logs][tags][Updatedat]"]


### PR DESCRIPTION
## Changes proposed in this pull request:

- [add mapping from `Spacename` Cloudwatch database logs to `@cf.space`](https://github.com/cloud-gov/opensearch-boshrelease/commit/561906f75f5737cea028bc2e62b98f3cb4c8e8f5)

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just updating Logstash filter to map tags on Cloudwatch logs correctly
