### PR TITLE
setting an interval of 1 instead of 60

### DIFF
--- a/jobs/ingestor_cloudwatch/templates/config/input_and_output.conf.erb
+++ b/jobs/ingestor_cloudwatch/templates/config/input_and_output.conf.erb
@@ -3,6 +3,7 @@ input
   cloudwatch_logs
   {
     log_group_prefix => true
+    interval => 1
     <% if_p("logstash_ingestor.cloudwatch.prefix") do |prefix_list| %>
     log_group => "<%= prefix_list %>"
     <% end %>


### PR DESCRIPTION
## Changes proposed in this pull request:

- interval to 1 so it can ingest in logs quicker, this should make it bring in logs at 60x the speed
-
-

## Security considerations
None
