### PR TITLE
update logstash filters for cloudwatch logs to drop unnecessary tags

### DIFF
--- a/jobs/ingestor_cloudwatch/templates/config/input_and_output.conf.erb
+++ b/jobs/ingestor_cloudwatch/templates/config/input_and_output.conf.erb
@@ -27,12 +27,11 @@ filter
         rename => {"[cloudwatch_logs][tags][InstanceGUID]"=>"[@cf][service_instance_id]"}
         rename => {"[cloudwatch_logs][tags][Serviceofferingname]"=>"[@cf][service_offering]"}
         rename => {"[cloudwatch_logs][tags][Serviceplanname]"=>"[@cf][service_plan]"}
-        rename => {"[cloudwatch_logs][tags][PlanGUID]"=>"[@cf][plan_id]"}
-        rename => {"[cloudwatch_logs][tags][ServiceGUID]"=>"[@cf][service_id]"}
         rename => {"[cloudwatch_logs][tags][service]"=>"broker"}
         rename => {"[cloudwatch_logs][tags][broker]"=>"broker"}
         remove_field => ["[cloudwatch_logs][tags][client]"]
-
+        remove_field => ["[cloudwatch_logs][tags][PlanGUID]"]
+        remove_field => ["[cloudwatch_logs][tags][ServiceGUID]"]
     }
 }
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- Drop tag values that are not useful for customers. The `PlanGUID` value is not actually the value of a CF service plan and the `ServiceGUID` value is not actually the GUID of a service offering

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None
