### PR TITLE
add field mappings for database log fields

### DIFF
--- a/jobs/opensearch_templates/templates/component-index-mappings-app.json.erb
+++ b/jobs/opensearch_templates/templates/component-index-mappings-app.json.erb
@@ -28,7 +28,9 @@ keyword_default = { "type": "keyword", "index": true }.to_json
             "space_id":     <%= keyword_default %>,
             "process_id":     <%= keyword_default %>,
             "process_instance_id": <%= keyword_default %>,
-            "process_type":  <%= keyword_default %>
+            "process_type":  <%= keyword_default %>,
+            "service_offering": <%= keyword_default %>,
+            "service_plan": <%= keyword_default %>
           }
         },
         "app": {


### PR DESCRIPTION
## Changes proposed in this pull request:

- Add index mappings for fields generated by database logs

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just adding field mappings so OpenSearch knows what type to use in the index for each field
