### PR TITLE
update logstash to 8.16.1

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -198,10 +198,10 @@ curator_opensearch/vendor/voluptuous-0.15.2-py3-none-any.whl:
   size: 31349
   object_id: cab6f4d3-79bd-4d78-4ff3-f10cfddb69c5
   sha: sha256:016348bc7788a9af9520b1764ebd4de0df41fe2138ebe9e06fa036bf86a65566
-logstash/logstash-8.9.2-linux-x86_64.tar.gz:
-  size: 346522558
-  object_id: 61bc773e-e0a2-4cf5-416e-0964a3d83978
-  sha: sha256:86eb38b40f66dea4f3c747582c53f574d88ea0c57b8f60325baa00022cbba998
+logstash/logstash-8.16.1-linux-x86_64.tar.gz:
+  size: 428558276
+  object_id: 6448195b-fb5b-4a22-5f16-759c29296cf6
+  sha: sha256:1245b05b83443c204f355ad8463cf9c9a0e2d6052d51578aeaaaadb7eb6ca214
 logstash/logstash-filter-alter-3.0.3.zip:
   size: 7655
   object_id: 552763c7-779b-4ac3-5993-04a06d967c93

--- a/packages/logstash/packaging
+++ b/packages/logstash/packaging
@@ -5,7 +5,7 @@ set -e -u
 # shellcheck disable=1091
 source /var/vcap/packages/openjdk-17/bosh/compile.env
 
-tar xzf logstash/logstash-8.9.2-linux-x86_64.tar.gz -C "${BOSH_INSTALL_TARGET}" --strip-components 1
+tar xzf logstash/logstash-8.16.1-linux-x86_64.tar.gz -C "${BOSH_INSTALL_TARGET}" --strip-components 1
 
 export PATH="${BOSH_INSTALL_TARGET}/bin:${PATH}"
 

--- a/packages/logstash/spec
+++ b/packages/logstash/spec
@@ -5,7 +5,7 @@ dependencies:
   - openjdk-17
 
 files:
-  - logstash/logstash-8.9.2-linux-x86_64.tar.gz
+  - logstash/logstash-8.16.1-linux-x86_64.tar.gz
   - logstash/logstash-filter-alter-3.0.3.zip
   - logstash/logstash-filter-translate-3.4.2.zip
   - logstash/logstash-input-relp-3.0.4.zip


### PR DESCRIPTION
## Changes proposed in this pull request:

Related to https://github.com/cloud-gov/opensearch-boshrelease/issues/134

- update logstash to 8.16.1, which includes JRuby-9.4.9.0

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Newer versions include bug fixes and security patches
