### PR TITLE
update logstash-input-cloudwatch_logs to version 1.1.3

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -210,10 +210,10 @@ logstash/logstash-filter-translate-3.4.2.zip:
   size: 649362
   object_id: e9b87119-265c-43ce-788d-5592aabffcb3
   sha: sha256:f465635431b474abaf61c6673d7c91cb5f62b09a193d45a5622342f5a5b967c6
-logstash/logstash-input-cloudwatch_logs-1.1.2.zip:
-  size: 2469347
-  object_id: 5720579d-1dd8-46c6-788a-be59c1f31e79
-  sha: sha256:bf3755dc83de19ff35ee30cd0caa9d6372764e6de6930c0323a7efacc6b41970
+logstash/logstash-input-cloudwatch_logs-1.1.3.zip:
+  size: 2469530
+  object_id: 905d9911-e294-4084-428e-89528fade8c9
+  sha: sha256:699f2a6eccc13ced8874824cc48956e96b6b988cba13779d96f0e2bfcb2f135e
 logstash/logstash-input-relp-3.0.4.zip:
   size: 44725
   object_id: 2e183484-97da-4e51-4311-51e024d0665b

--- a/packages/logstash/packaging
+++ b/packages/logstash/packaging
@@ -17,4 +17,4 @@ logstash-plugin install --no-verify "file://${PWD}/logstash/logstash-input-syslo
 logstash-plugin install --no-verify "file://${PWD}/logstash/logstash-input-tcp-6.4.1.zip"
 logstash-plugin install --no-verify "file://${PWD}/logstash/logstash-output-syslog-3.0.5.zip"
 logstash-plugin install --no-verify "file://${PWD}/logstash/logstash-output-opensearch-2.0.2.zip"
-logstash-plugin install --no-verify "file://${PWD}/logstash/logstash-input-cloudwatch_logs-1.1.2.zip"
+logstash-plugin install --no-verify "file://${PWD}/logstash/logstash-input-cloudwatch_logs-1.1.3.zip"

--- a/packages/logstash/spec
+++ b/packages/logstash/spec
@@ -13,4 +13,4 @@ files:
   - logstash/logstash-input-tcp-6.4.1.zip
   - logstash/logstash-output-syslog-3.0.5.zip
   - logstash/logstash-output-opensearch-2.0.2.zip
-  - logstash/logstash-input-cloudwatch_logs-1.1.2.zip
+  - logstash/logstash-input-cloudwatch_logs-1.1.3.zip


### PR DESCRIPTION
## Changes proposed in this pull request:

- Update blob for logstash-input-cloudwatch_logs plugin to version 1.1.3 to include https://github.com/cloud-gov/logstash-input-cloudwatch-logs/pull/12

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

See https://github.com/cloud-gov/logstash-input-cloudwatch-logs/pull/12
