### PR TITLE
fix invalid blob references

### DIFF
--- a/packages/logstash/packaging
+++ b/packages/logstash/packaging
@@ -17,4 +17,4 @@ logstash-plugin install --no-verify "file://${PWD}/logstash/logstash-input-syslo
 logstash-plugin install --no-verify "file://${PWD}/logstash/logstash-input-tcp-6.4.1.zip"
 logstash-plugin install --no-verify "file://${PWD}/logstash/logstash-output-syslog-3.0.5.zip"
 logstash-plugin install --no-verify "file://${PWD}/logstash/logstash-output-opensearch-2.0.2.zip"
-logstash-plugin install --no-verify "file://${PWD}/logstash/logstash-input-cloudwatch_logs-1.1.4.zip.zip"
+logstash-plugin install --no-verify "file://${PWD}/logstash/logstash-input-cloudwatch_logs-1.1.4.zip"

--- a/packages/logstash/spec
+++ b/packages/logstash/spec
@@ -13,4 +13,4 @@ files:
   - logstash/logstash-input-tcp-6.4.1.zip
   - logstash/logstash-output-syslog-3.0.5.zip
   - logstash/logstash-output-opensearch-2.0.2.zip
-  - logstash/logstash-input-cloudwatch_logs-1.1.4.zip.zip
+  - logstash/logstash-input-cloudwatch_logs-1.1.4.zip


### PR DESCRIPTION
## Changes proposed in this pull request:

- Fixing invalid blob names

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just fixing references to invalid blobs
