### PR TITLE
update job to set default index for timeline visualizations

### DIFF
--- a/jobs/upload-dashboards-objects/templates/bin/import-objects
+++ b/jobs/upload-dashboards-objects/templates/bin/import-objects
@@ -85,7 +85,7 @@ if __name__ == "__main__":
         }
         r = session.post(
           '{}/api/opensearch-dashboards/settings'.format(logs_url),
-          data='{"changes":{"defaultIndex":"<%= p('dashboards_objects.default_index') %>"}}',
+          data='{"changes":{"defaultIndex":"<%= p('dashboards_objects.default_index') %>", "timeline:es.default_index": "<%= p('dashboards_objects.default_index') %>"}}',
           headers=index_headers,
           cert=(cert, key),
           verify=ca


### PR DESCRIPTION
## Changes proposed in this pull request:

Fixes https://github.com/cloud-gov/opensearch-boshrelease/issues/145

- update job to set default index for timeline visualizations, otherwise users get permission errors trying to visualize data from other indices which they cannot access

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

These changes do not increase permissions, they update the visualization settings to only read data from the default index where their logs are stored.
