### PR TITLE
Fix tenant deletion on update

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,5 +1,5 @@
-? auth-proxy/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-: size: 23118
+auth-proxy/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl:
+  size: 23118
   object_id: 90e64af5-1a04-4f54-75ce-4e5984294f03
   sha: sha256:e17c96c14e19278594aa4841ec148115f9c7615a47382ecb6b82bd8fea3ab0c8
 auth-proxy/PyJWT-2.9.0-py3-none-any.whl:
@@ -22,20 +22,20 @@ auth-proxy/certifi-2024.8.30-py3-none-any.whl:
   size: 167321
   object_id: 437fca17-3a4e-4088-6cb4-6cb58ddbe4db
   sha: sha256:922820b53db7a7257ffbda3f597266d435245903d80737e34f8a45ff3e3230d8
-? auth-proxy/cffi-1.17.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-: size: 479424
+auth-proxy/cffi-1.17.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl:
+  size: 479424
   object_id: 93cbfef5-f135-487b-5d34-ff797b1fbffc
   sha: sha256:b62ce867176a75d03a665bad002af8e6d54644fad99a3c70905c543130e39d93
-? auth-proxy/charset_normalizer-3.4.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-: size: 143838
+auth-proxy/charset_normalizer-3.4.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl:
+  size: 143838
   object_id: 1017c0b8-42fb-449f-690c-723e63a56a1d
   sha: sha256:8cda06946eac330cbe6598f77bb54e690b4ca93f593dee1568ad22b04f347c15
 auth-proxy/click-8.1.7-py3-none-any.whl:
   size: 97941
   object_id: 079a6e28-41d8-476a-6ed5-d1643cd55a24
   sha: sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28
-? auth-proxy/cryptography-43.0.3-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-: size: 3977754
+auth-proxy/cryptography-43.0.3-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl:
+  size: 3977754
   object_id: 9ac4b6d2-490a-408e-5e43-5181234a6883
   sha: sha256:0f996e7268af62598f2fc1204afa98a3b5712313a55c4c9d434aef49cadc91d4
 auth-proxy/dnspython-2.7.0-py3-none-any.whl:
@@ -58,8 +58,8 @@ auth-proxy/flask_session-0.8.0-py3-none-any.whl:
   size: 24410
   object_id: be9335c8-8973-4f28-7d4f-0a24080e7acc
   sha: sha256:5dae6e9ddab334f8dc4dea4305af37851f4e7dc0f484caf3351184001195e3b7
-? auth-proxy/greenlet-3.1.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-: size: 660105
+auth-proxy/greenlet-3.1.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl:
+  size: 660105
   object_id: 23fe2446-463c-453d-4602-967473e7547f
   sha: sha256:99cfaa2110534e2cf3ba31a7abcac9d328d1d9f1b95beede58294a60348fba36
 auth-proxy/gunicorn-23.0.0-py3-none-any.whl:
@@ -86,8 +86,8 @@ auth-proxy/marshmallow-3.23.1-py3-none-any.whl:
   size: 49488
   object_id: 3ab529b7-9edb-494f-4e51-c09c11e5b392
   sha: sha256:fece2eb2c941180ea1b7fcbd4a83c51bfdd50093fdd3ad2585ee5e1df2508491
-? auth-proxy/msgspec-0.18.6-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-: size: 212510
+auth-proxy/msgspec-0.18.6-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl:
+  size: 212510
   object_id: 211dd7e2-ff78-4903-59a6-60e743cb818f
   sha: sha256:ad237100393f637b297926cae1868b0d500f764ccd2f0623a380e2bcfb2809ca
 auth-proxy/packaging-24.1-py3-none-any.whl:
@@ -130,8 +130,8 @@ curator_opensearch/vendor/Events-0.5-py3-none-any.whl:
   size: 6758
   object_id: e97f361f-72f4-448f-490a-886f65c053b5
   sha: sha256:a7286af378ba3e46640ac9825156c93bdba7502174dd696090fdfcd4d80a1abd
-? curator_opensearch/vendor/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-: size: 767542
+curator_opensearch/vendor/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl:
+  size: 767542
   object_id: 1a94d4cb-82e9-4c5a-60d4-ef18ebbea1b4
   sha: sha256:80bab7bfc629882493af4aa31a4cfa43a4c57c83813253626916b8c7ada83476
 curator_opensearch/vendor/boto3-1.35.55-py3-none-any.whl:
@@ -146,8 +146,8 @@ curator_opensearch/vendor/certifi-2024.8.30-py3-none-any.whl:
   size: 167321
   object_id: f9859e14-b0ef-4d3d-7fd5-3b49f604943c
   sha: sha256:922820b53db7a7257ffbda3f597266d435245903d80737e34f8a45ff3e3230d8
-? curator_opensearch/vendor/charset_normalizer-3.4.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-: size: 143838
+curator_opensearch/vendor/charset_normalizer-3.4.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl:
+  size: 143838
   object_id: b20e567d-d590-474e-69c0-6d8e9090bea5
   sha: sha256:8cda06946eac330cbe6598f77bb54e690b4ca93f593dee1568ad22b04f347c15
 curator_opensearch/vendor/click-7.1.2-py2.py3-none-any.whl:
@@ -274,3 +274,7 @@ ruby/rake-13.0.6.gem:
   size: 84992
   object_id: ae89e0d2-b8d0-454f-6eff-6673b2956ada
   sha: sha256:5ce4bf5037b4196c24ac62834d8db1ce175470391026bd9e557d669beeb19097
+yq_darwin_amd64-4.4.6.tar.gz:
+  size: 4257765
+  object_id: 612e4c6a-d3e3-4031-5bcd-fbe5ce8ddb58
+  sha: sha256:88a2d9075c4f59f5e9cf6e6d1a5ec8b84fa7f094566829c76d1e80fd61da274a

--- a/jobs/opensearch/spec
+++ b/jobs/opensearch/spec
@@ -1,7 +1,7 @@
 ---
 name: opensearch
 
-description: This job runs opensearch node (master or data)
+description: This job runs opensearch node (manager or data)
 
 packages:
   - opensearch

--- a/jobs/opensearch/spec
+++ b/jobs/opensearch/spec
@@ -187,3 +187,9 @@ properties:
   opensearch.multitenancy.private_tenant_enabled:
     description: True to enable private tenant
     default: false
+  opensearch.cf.domain:
+    description: domain of the api for cf
+  opensearch.cf.client_id:
+    description: username of the cf client
+  opensearch.cf.client_password:
+    description: password of cf client    

--- a/jobs/opensearch/spec
+++ b/jobs/opensearch/spec
@@ -6,6 +6,7 @@ description: This job runs opensearch node (master or data)
 packages:
   - opensearch
   - openjdk-17
+  - jq
 
 templates:
   # bin/drain.erb: bin/drain

--- a/jobs/opensearch/templates/bin/pre-start.erb
+++ b/jobs/opensearch/templates/bin/pre-start.erb
@@ -6,6 +6,7 @@ export JOB_DIR=/var/vcap/jobs/$JOB_NAME
 export OPENSEARCH_PATH_CONF=${JOB_DIR}/config
 export YQ_PACKAGE_DIR=/var/vcap/packages/yq
 export PATH=$YQ_PACKAGE_DIR/bin:$PATH
+export OPENSEARCH_SECURITY_CONFIG_PATH=${OPENSEARCH_PATH_CONF}/opensearch-security
 
 sysctl -q -w vm.max_map_count=262144
 mkdir -p ${OPENSEARCH_HOME}/plugins
@@ -17,7 +18,7 @@ source /var/vcap/packages/openjdk-17/bosh/runtime.env
 
 # Copy default security config if it doesn't already exist
 # Have to copy files that don't exist otherwise securityadmin.sh invocation will fail
-cp -u ${OPENSEARCH_HOME}/config/opensearch-security/*.yml ${OPENSEARCH_PATH_CONF}/opensearch-security
+cp -u ${OPENSEARCH_HOME}/config/opensearch-security/*.yml "$OPENSEARCH_SECURITY_CONFIG_PATH"
 
 <%
   api = p("opensearch.cf.domain")
@@ -29,7 +30,7 @@ cf auth "<%= client %>" "<%= password %>" --client-credentials
 
 cd ${OPENSEARCH_HOME}
 chown -R vcap:vcap config plugins
-chown -R vcap:vcap ${OPENSEARCH_PATH_CONF}/opensearch-security
+chown -R vcap:vcap "$OPENSEARCH_SECURITY_CONFIG_PATH"
 
 # Prepare tenants, roles, and role mappings so that they don't get overridden by securityadmin.sh
 # script invocation in post-start
@@ -37,9 +38,9 @@ for org in $(cf orgs | tail -n +4); do
   ORG_GUID=$(cf org "$org" --guid)
   ROLE_NAME="$org-tenant"
 
-  yq -i ".\"$org\"={\"description\":\"tenant for $org\"}" "$OPENSEARCH_PATH_CONF/opensearch-security/tenants.yml"
-  yq -i ".\"$ROLE_NAME\"={\"tenant_permissions\":[{\"tenant_patterns\": [\"$org\"],\"allowed_actions\": [\"kibana_all_write\"]}]}" "$OPENSEARCH_PATH_CONF/opensearch-security/roles.yml"
-  yq -i ".\"$ROLE_NAME\"={\"backend_roles\": [\"$ORG_GUID\"]}" "$OPENSEARCH_PATH_CONF/opensearch-security/roles_mapping.yml"
+  yq -i ".\"$org\"={\"description\":\"tenant for $org\"}" "$OPENSEARCH_SECURITY_CONFIG_PATH/tenants.yml"
+  yq -i ".\"$ROLE_NAME\"={\"tenant_permissions\":[{\"tenant_patterns\": [\"$org\"],\"allowed_actions\": [\"kibana_all_write\"]}]}" "$OPENSEARCH_SECURITY_CONFIG_PATH/roles.yml"
+  yq -i ".\"$ROLE_NAME\"={\"backend_roles\": [\"$ORG_GUID\"]}" "$OPENSEARCH_SECURITY_CONFIG_PATH/roles_mapping.yml"
 done
 
 # leaving all plugin files and plugins installed for now

--- a/jobs/opensearch/templates/bin/pre-start.erb
+++ b/jobs/opensearch/templates/bin/pre-start.erb
@@ -4,6 +4,8 @@ export JOB_NAME=opensearch
 export OPENSEARCH_HOME=/var/vcap/packages/opensearch
 export JOB_DIR=/var/vcap/jobs/$JOB_NAME
 export OPENSEARCH_PATH_CONF=${JOB_DIR}/config
+export YQ_PACKAGE_DIR=/var/vcap/packages/yq
+export PATH=$YQ_PACKAGE_DIR/bin:$PATH
 
 sysctl -q -w vm.max_map_count=262144
 mkdir -p ${OPENSEARCH_HOME}/plugins

--- a/jobs/opensearch/templates/bin/pre-start.erb
+++ b/jobs/opensearch/templates/bin/pre-start.erb
@@ -14,7 +14,7 @@ fi
 source /var/vcap/packages/openjdk-17/bosh/runtime.env
 
 # Copy default security config if it doesn't already exist
-# TODO: Should this be necessary?
+# Have to copy files that don't exist otherwise securityadmin.sh invocation will fail
 cp -u ${OPENSEARCH_HOME}/config/opensearch-security/*.yml ${OPENSEARCH_PATH_CONF}/opensearch-security
 
 cd ${OPENSEARCH_HOME}

--- a/jobs/opensearch/templates/bin/pre-start.erb
+++ b/jobs/opensearch/templates/bin/pre-start.erb
@@ -26,12 +26,21 @@ cp -u ${OPENSEARCH_HOME}/config/opensearch-security/*.yml ${OPENSEARCH_PATH_CONF
 %>
 cf api "<%= api %>"
 cf auth "<%= client %>" "<%= password %>" --client-credentials
-cf orgs | tail -n +4 | xargs -I {} yq -i '."{}"={"description":"tenant for {}"}' ${OPENSEARCH_PATH_CONF}/opensearch-security
-/tenants.yml
 
 cd ${OPENSEARCH_HOME}
 chown -R vcap:vcap config plugins
 chown -R vcap:vcap ${OPENSEARCH_PATH_CONF}/opensearch-security
+
+# Prepare tenants, roles, and role mappings so that they don't get overridden by securityadmin.sh
+# script invocation in post-start
+for org in $(cf orgs | tail -n +4); do
+  ORG_GUID=$(cf org "$org" --guid)
+  ROLE_NAME="$org-tenant"
+
+  yq -i ".\"$org\"={\"description\":\"tenant for $org\"}" "$OPENSEARCH_PATH_CONF/opensearch-security/tenants.yml"
+  yq -i ".\"$ROLE_NAME\"={\"tenant_permissions\":[{\"tenant_patterns\": [\"$org\"],\"allowed_actions\": [\"kibana_all_write\"]}]}" "$OPENSEARCH_PATH_CONF/opensearch-security/roles.yml"
+  yq -i ".\"$ROLE_NAME\"={\"backend_roles\": [\"$ORG_GUID\"]}" "$OPENSEARCH_PATH_CONF/opensearch-security/roles_mapping.yml"
+done
 
 # leaving all plugin files and plugins installed for now
 # can revisit https://opensearch.org/docs/latest/install-and-configure/plugins/ for how to

--- a/jobs/opensearch/templates/bin/pre-start.erb
+++ b/jobs/opensearch/templates/bin/pre-start.erb
@@ -17,6 +17,16 @@ source /var/vcap/packages/openjdk-17/bosh/runtime.env
 # Have to copy files that don't exist otherwise securityadmin.sh invocation will fail
 cp -u ${OPENSEARCH_HOME}/config/opensearch-security/*.yml ${OPENSEARCH_PATH_CONF}/opensearch-security
 
+<%
+  api = p("opensearch.cf.domain")
+  client = p("opensearch.cf.client_id")
+  password = p("opensearch.cf.client_password")
+%>
+cf api "<%= api %>"
+cf auth "<%= client %>" "<%= password %>" --client-credentials
+cf orgs | tail -n +4 | xargs -I {} yq -i '."{}"={"description":"tenant for {}"}' ${OPENSEARCH_PATH_CONF}/opensearch-security
+/tenants.yml
+
 cd ${OPENSEARCH_HOME}
 chown -R vcap:vcap config plugins
 chown -R vcap:vcap ${OPENSEARCH_PATH_CONF}/opensearch-security

--- a/jobs/upload_tenant/spec
+++ b/jobs/upload_tenant/spec
@@ -7,7 +7,7 @@ packages:
   - cf-cli-8-linux
 
 templates:
-  bin/run.sh: bin/run
+  bin/run.sh.erb: bin/run
   bin/pre-start.erb: bin/pre-start
   config/admin-crt.erb: config/ssl/opensearch-admin.crt
   config/admin-pem.erb: config/ssl/opensearch-admin.pem

--- a/jobs/upload_tenant/templates/bin/run.sh
+++ b/jobs/upload_tenant/templates/bin/run.sh
@@ -24,7 +24,7 @@ org_quoted=\"$org\"
 curl -X PUT \
   ${CA} ${CERT} ${KEY} \
   -s https://localhost:9200/_plugins/_security/api/tenants/${org} \
-  -H 'Content-Type: application/json' -d "{ \"description\": \"A tenant for the ${org} team.\" }"
+  -H 'Content-Type: application/json' -d "{\"description\": \"A tenant for the ${org} team.\"}"
   
 curl -X PUT \
   ${CA} ${CERT} ${KEY} \

--- a/jobs/upload_tenant/templates/bin/run.sh
+++ b/jobs/upload_tenant/templates/bin/run.sh
@@ -18,22 +18,23 @@ KEY="--key ${JOB_DIR}/config/ssl/opensearch-admin.key"
 cf api "<%= api %>"
 cf auth "<%= client %>" "<%= password %>" --client-credentials
 
-for org in `cf orgs| tail -n +4`; do
+for org in `cf orgs | tail -n +4`; do
 ORG_GUID=\"$(cf org ${org} --guid)\"
 org_quoted=\"$org\"
 curl -X PUT \
   ${CA} ${CERT} ${KEY} \
   -s https://localhost:9200/_plugins/_security/api/tenants/${org} \
-  -H 'Content-Type: application/json' -d'{ "description": "A tenant for the ${org} team." }'
+  -H 'Content-Type: application/json' -d "{ \"description\": \"A tenant for the ${org} team.\" }"
+  
 curl -X PUT \
   ${CA} ${CERT} ${KEY} \
   -s https://localhost:9200/_plugins/_security/api/roles/${org}-tenant \
-  -H 'Content-Type: application/json' -d'{"tenant_permissions":[{"tenant_patterns": ['"${org_quoted}"'],"allowed_actions": ["kibana_all_write"]}]}'
+  -H 'Content-Type: application/json' -d '{"tenant_permissions":[{"tenant_patterns": ['"${org_quoted}"'],"allowed_actions": ["kibana_all_write"]}]}'
 
 curl -X PUT \
   ${CA} ${CERT} ${KEY} \
   -s https://localhost:9200/_plugins/_security/api/rolesmapping/${org}-tenant \
-  -H 'Content-Type: application/json' -d'{"backend_roles": ['${ORG_GUID}']}'
+  -H 'Content-Type: application/json' -d '{"backend_roles": ['${ORG_GUID}']}'
 
 done
 

--- a/jobs/upload_tenant/templates/bin/run.sh.erb
+++ b/jobs/upload_tenant/templates/bin/run.sh.erb
@@ -10,6 +10,7 @@ export CF_COLOR=false
 CA="--cacert ${JOB_DIR}/config/ssl/opensearch.ca"
 CERT="--cert ${JOB_DIR}/config/ssl/opensearch-admin.crt"
 KEY="--key ${JOB_DIR}/config/ssl/opensearch-admin.key"
+
 <%
   api = p("upload_tenant.cf.domain")
   client = p("upload_tenant.cf.client_id")

--- a/packages/opensearch/packaging
+++ b/packages/opensearch/packaging
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 set -e
 
-tar xzf opensearch-2.18.0-linux-x64.tar.gz -C $BOSH_INSTALL_TARGET --strip-components 1
+tar xzf opensearch-2.18.0-linux-x64.tar.gz -C "$BOSH_INSTALL_TARGET" --strip-components 1

--- a/packages/yq/packaging
+++ b/packages/yq/packaging
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+tar xzf yq_darwin_amd64-4.4.6.tar.gz -C "$BOSH_INSTALL_TARGET" --strip-components 1

--- a/packages/yq/packaging
+++ b/packages/yq/packaging
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
 
 tar xzf yq_darwin_amd64-4.4.6.tar.gz -C "$BOSH_INSTALL_TARGET" --strip-components 1
+mkdir "$BOSH_INSTALL_TARGET/bin"
+cp "$BOSH_INSTALL_TARGET/yq_darwin_amd64" "$BOSH_INSTALL_TARGET/bin/yq"

--- a/packages/yq/spec
+++ b/packages/yq/spec
@@ -1,0 +1,5 @@
+---
+name: yq
+
+files:
+  - yq_darwin_amd64-4.4.6.tar.gz


### PR DESCRIPTION
## Changes proposed in this pull request:

Related to https://github.com/cloud-gov/opensearch-boshrelease/issues/150

- Add yq package
- Update opensearch job pre-start script to prepare YAML configuration for tenants, roles, and role_mappings for CF orgs so that they are not deleted when securityadmin.sh runs in the post-start script

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

We are not adding new permissions or roles, just ensuring that they do not get deleted when the opensearch job restarts
