### PR TITLE
fix package name reference from jq to yq

### DIFF
--- a/jobs/opensearch/spec
+++ b/jobs/opensearch/spec
@@ -6,7 +6,7 @@ description: This job runs opensearch node (manager or data)
 packages:
   - opensearch
   - openjdk-17
-  - jq
+  - yq
 
 templates:
   # bin/drain.erb: bin/drain


### PR DESCRIPTION
## Changes proposed in this pull request:

Related to https://github.com/cloud-gov/opensearch-boshrelease/issues/150

- fix package name reference from jq to yq

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just fixing typo
