### PR TITLE
update pre-start script to only expect CF properties on data nodes

### DIFF
--- a/jobs/opensearch/templates/bin/pre-start.erb
+++ b/jobs/opensearch/templates/bin/pre-start.erb
@@ -20,6 +20,7 @@ source /var/vcap/packages/openjdk-17/bosh/runtime.env
 # Have to copy files that don't exist otherwise securityadmin.sh invocation will fail
 cp -u ${OPENSEARCH_HOME}/config/opensearch-security/*.yml "$OPENSEARCH_SECURITY_CONFIG_PATH"
 
+<% if p("opensearch.node.allow_data") %>
 <%
   api = p("opensearch.cf.domain")
   client = p("opensearch.cf.client_id")
@@ -42,6 +43,7 @@ for org in $(cf orgs | tail -n +4); do
   yq -i ".\"$ROLE_NAME\"={\"tenant_permissions\":[{\"tenant_patterns\": [\"$org\"],\"allowed_actions\": [\"kibana_all_write\"]}]}" "$OPENSEARCH_SECURITY_CONFIG_PATH/roles.yml"
   yq -i ".\"$ROLE_NAME\"={\"backend_roles\": [\"$ORG_GUID\"]}" "$OPENSEARCH_SECURITY_CONFIG_PATH/roles_mapping.yml"
 done
+<% end %>
 
 # leaving all plugin files and plugins installed for now
 # can revisit https://opensearch.org/docs/latest/install-and-configure/plugins/ for how to

--- a/jobs/opensearch/templates/bin/pre-start.erb
+++ b/jobs/opensearch/templates/bin/pre-start.erb
@@ -21,6 +21,7 @@ source /var/vcap/packages/openjdk-17/bosh/runtime.env
 cp -u ${OPENSEARCH_HOME}/config/opensearch-security/*.yml "$OPENSEARCH_SECURITY_CONFIG_PATH"
 
 <% if p("opensearch.node.allow_data") %>
+<% if_p('opensearch.cf.domain', 'opensearch.cf.client_id', 'opensearch.cf.client_password') do %>
 <%
   api = p("opensearch.cf.domain")
   client = p("opensearch.cf.client_id")
@@ -43,6 +44,7 @@ for org in $(cf orgs | tail -n +4); do
   yq -i ".\"$ROLE_NAME\"={\"tenant_permissions\":[{\"tenant_patterns\": [\"$org\"],\"allowed_actions\": [\"kibana_all_write\"]}]}" "$OPENSEARCH_SECURITY_CONFIG_PATH/roles.yml"
   yq -i ".\"$ROLE_NAME\"={\"backend_roles\": [\"$ORG_GUID\"]}" "$OPENSEARCH_SECURITY_CONFIG_PATH/roles_mapping.yml"
 done
+<% end %>
 <% end %>
 
 # leaving all plugin files and plugins installed for now


### PR DESCRIPTION
## Changes proposed in this pull request:

Related to https://github.com/cloud-gov/opensearch-boshrelease/issues/150

- update pre-start script to only expect CF properties on data nodes since only those needs run the securityadmin.sh script and need to prepare the security config files

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just fixing deployment errors
