### PR TITLE
add CF package to opensearch job

### DIFF
--- a/jobs/opensearch/spec
+++ b/jobs/opensearch/spec
@@ -7,6 +7,7 @@ packages:
   - opensearch
   - openjdk-17
   - yq
+  - cf-cli-8-linux
 
 templates:
   # bin/drain.erb: bin/drain

--- a/jobs/opensearch/templates/bin/pre-start.erb
+++ b/jobs/opensearch/templates/bin/pre-start.erb
@@ -20,8 +20,12 @@ source /var/vcap/packages/openjdk-17/bosh/runtime.env
 # Have to copy files that don't exist otherwise securityadmin.sh invocation will fail
 cp -u ${OPENSEARCH_HOME}/config/opensearch-security/*.yml "$OPENSEARCH_SECURITY_CONFIG_PATH"
 
-<% if p("opensearch.node.allow_data") %>
+cd ${OPENSEARCH_HOME}
+chown -R vcap:vcap config plugins
+chown -R vcap:vcap "$OPENSEARCH_SECURITY_CONFIG_PATH"
+
 <% if_p('opensearch.cf.domain', 'opensearch.cf.client_id', 'opensearch.cf.client_password') do %>
+<% if p("opensearch.node.allow_data") %>
 <%
   api = p("opensearch.cf.domain")
   client = p("opensearch.cf.client_id")
@@ -29,10 +33,6 @@ cp -u ${OPENSEARCH_HOME}/config/opensearch-security/*.yml "$OPENSEARCH_SECURITY_
 %>
 cf api "<%= api %>"
 cf auth "<%= client %>" "<%= password %>" --client-credentials
-
-cd ${OPENSEARCH_HOME}
-chown -R vcap:vcap config plugins
-chown -R vcap:vcap "$OPENSEARCH_SECURITY_CONFIG_PATH"
 
 # Prepare tenants, roles, and role mappings so that they don't get overridden by securityadmin.sh
 # script invocation in post-start


### PR DESCRIPTION
## Changes proposed in this pull request:

Related to https://github.com/cloud-gov/opensearch-boshrelease/issues/150

- add CF package to opensearch job for pre-start script

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just adding missing package for pre-start script
