### PR TITLE
Fix yq blob

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -274,7 +274,7 @@ ruby/rake-13.0.6.gem:
   size: 84992
   object_id: ae89e0d2-b8d0-454f-6eff-6673b2956ada
   sha: sha256:5ce4bf5037b4196c24ac62834d8db1ce175470391026bd9e557d669beeb19097
-yq_linux_amd64.tar.gz-4.44.6.tar.gz:
+yq_linux_amd64-4.44.6.tar.gz:
   size: 4196529
-  object_id: 15e6912e-9b87-4a6d-58d5-bcfef74405e7
+  object_id: cc6157b3-5ba0-4996-60e3-d90c8a150110
   sha: sha256:09ea7643cba1cfde4c57abbadbf7fa242d7425db8ee93c0b184d68661cf3b1bd

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -274,7 +274,7 @@ ruby/rake-13.0.6.gem:
   size: 84992
   object_id: ae89e0d2-b8d0-454f-6eff-6673b2956ada
   sha: sha256:5ce4bf5037b4196c24ac62834d8db1ce175470391026bd9e557d669beeb19097
-yq_darwin_amd64-4.4.6.tar.gz:
-  size: 4257765
-  object_id: 612e4c6a-d3e3-4031-5bcd-fbe5ce8ddb58
-  sha: sha256:88a2d9075c4f59f5e9cf6e6d1a5ec8b84fa7f094566829c76d1e80fd61da274a
+yq_linux_amd64.tar.gz-4.44.6.tar.gz:
+  size: 4196529
+  object_id: 15e6912e-9b87-4a6d-58d5-bcfef74405e7
+  sha: sha256:09ea7643cba1cfde4c57abbadbf7fa242d7425db8ee93c0b184d68661cf3b1bd

--- a/jobs/opensearch/templates/bin/pre-start.erb
+++ b/jobs/opensearch/templates/bin/pre-start.erb
@@ -4,9 +4,11 @@ export JOB_NAME=opensearch
 export OPENSEARCH_HOME=/var/vcap/packages/opensearch
 export JOB_DIR=/var/vcap/jobs/$JOB_NAME
 export OPENSEARCH_PATH_CONF=${JOB_DIR}/config
+export OPENSEARCH_SECURITY_CONFIG_PATH=${OPENSEARCH_PATH_CONF}/opensearch-security
+
 export YQ_PACKAGE_DIR=/var/vcap/packages/yq
 export PATH=$YQ_PACKAGE_DIR/bin:$PATH
-export OPENSEARCH_SECURITY_CONFIG_PATH=${OPENSEARCH_PATH_CONF}/opensearch-security
+export PATH=/var/vcap/packages/cf-cli-8-linux/bin:$PATH
 
 sysctl -q -w vm.max_map_count=262144
 mkdir -p ${OPENSEARCH_HOME}/plugins

--- a/packages/yq/packaging
+++ b/packages/yq/packaging
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-tar xzf yq_linux_amd64.tar.gz-4.44.6.tar.gz -C "$BOSH_INSTALL_TARGET" --strip-components 1
+tar xzf yq_linux_amd64-4.44.6.tar.gz -C "$BOSH_INSTALL_TARGET" --strip-components 1
 mkdir "$BOSH_INSTALL_TARGET/bin"
 cp "$BOSH_INSTALL_TARGET/yq_linux_amd64" "$BOSH_INSTALL_TARGET/bin/yq"

--- a/packages/yq/packaging
+++ b/packages/yq/packaging
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-tar xzf yq_darwin_amd64-4.4.6.tar.gz -C "$BOSH_INSTALL_TARGET" --strip-components 1
+tar xzf yq_linux_amd64.tar.gz-4.44.6.tar.gz -C "$BOSH_INSTALL_TARGET" --strip-components 1
 mkdir "$BOSH_INSTALL_TARGET/bin"
-cp "$BOSH_INSTALL_TARGET/yq_darwin_amd64" "$BOSH_INSTALL_TARGET/bin/yq"
+cp "$BOSH_INSTALL_TARGET/yq_linux_amd64" "$BOSH_INSTALL_TARGET/bin/yq"

--- a/packages/yq/spec
+++ b/packages/yq/spec
@@ -2,4 +2,4 @@
 name: yq
 
 files:
-  - yq_darwin_amd64-4.4.6.tar.gz
+  - yq_linux_amd64.tar.gz-4.44.6.tar.gz

--- a/packages/yq/spec
+++ b/packages/yq/spec
@@ -2,4 +2,4 @@
 name: yq
 
 files:
-  - yq_linux_amd64.tar.gz-4.44.6.tar.gz
+  - yq_linux_amd64-4.44.6.tar.gz


### PR DESCRIPTION
## Changes proposed in this pull request:

Related to https://github.com/cloud-gov/opensearch-boshrelease/issues/150

Right now, we get an error trying to run `yq` because the included blob is for the wrong architecture: Darwin (Mac) instead of Linux:

```
cannot execute binary file: Exec format error
```

This PR updates the `yq` blob to use Linux architecture instead of Darwin (Mac) architecture

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just fixing blob so `yq` can run successfully on the VMs
