### PR TITLE
update logstash filters for ingestor_cloudwatch 

### DIFF
--- a/jobs/ingestor_cloudwatch/templates/config/input_and_output.conf.erb
+++ b/jobs/ingestor_cloudwatch/templates/config/input_and_output.conf.erb
@@ -18,25 +18,42 @@ filter
 {
     mutate {
         rename => {"[cloudwatch_logs][tags][environment]"=>"environment"}
+        
         rename => {"[cloudwatch_logs][tags][OrganizationGUID]"=>"[@cf][org_id]"}
+        rename => {"[cloudwatch_logs][tags][Organization GUID]"=>"[@cf][org_id]"}
+        
         rename => {"[cloudwatch_logs][tags][SpaceGUID]"=>"[@cf][space_id]"}
+        rename => {"[cloudwatch_logs][tags][Space GUID]"=>"[@cf][space_id]"}
+        
         rename => {"[cloudwatch_logs][tags][Spacename]"=>"[@cf][space]"}
+        rename => {"[cloudwatch_logs][tags][Space name]"=>"[@cf][space]"}
+        
         rename => {"[cloudwatch_logs][tags][Organizationname]"=>"[@cf][org]"}
-        remove_field => ["[cloudwatch_logs][tags][Createdat]"]
-        remove_field => ["[cloudwatch_logs][tags][Updatedat]"]
+        rename => {"[cloudwatch_logs][tags][Organization name]"=>"[@cf][org]"}
+        
         rename => {"[cloudwatch_logs][tags][InstanceGUID]"=>"[@cf][service_instance_id]"}
+        rename => {"[cloudwatch_logs][tags][Instance GUID]"=>"[@cf][service_instance_id]"}
+
+        rename => {"[cloudwatch_logs][tags][Instance name]"=>"[@cf][service]"}
+
         rename => {"[cloudwatch_logs][tags][Serviceofferingname]"=>"[@cf][service_offering]"}
-        rename => {"[cloudwatch_logs][tags][Serviceplanname]"=>"[@cf][service_plan]"}
+        rename => {"[cloudwatch_logs][tags][Service offering name]"=>"[@cf][service_offering]"}
+
+        rename => {"[cloudwatch_logs][tags][Service plan name]"=>"[@cf][service_plan]"}
+
         rename => {"[cloudwatch_logs][tags][service]"=>"broker"}
         rename => {"[cloudwatch_logs][tags][broker]"=>"broker"}
+
+        remove_field => ["[cloudwatch_logs][tags][Createdat]"]
+        remove_field => ["[cloudwatch_logs][tags][Updatedat]"]
         remove_field => ["[cloudwatch_logs][tags][client]"]
         remove_field => ["[cloudwatch_logs][tags][PlanGUID]"]
         remove_field => ["[cloudwatch_logs][tags][ServiceGUID]"]
     }
     truncate {
-            fields => ["message"]
-            add_tag => [ "_logtrimmed" ]
-            length_bytes => 32765
+      fields => ["message"]
+      add_tag => [ "_logtrimmed" ]
+      length_bytes => 32765
     }
 }
 

--- a/jobs/ingestor_cloudwatch/templates/config/input_and_output.conf.erb
+++ b/jobs/ingestor_cloudwatch/templates/config/input_and_output.conf.erb
@@ -45,10 +45,14 @@ filter
         rename => {"[cloudwatch_logs][tags][broker]"=>"broker"}
 
         remove_field => ["[cloudwatch_logs][tags][Createdat]"]
+        remove_field => ["[cloudwatch_logs][tags][Created at]"]
         remove_field => ["[cloudwatch_logs][tags][Updatedat]"]
+        remove_field => ["[cloudwatch_logs][tags][Updateda t]"]
         remove_field => ["[cloudwatch_logs][tags][client]"]
         remove_field => ["[cloudwatch_logs][tags][PlanGUID]"]
+        remove_field => ["[cloudwatch_logs][tags][Plan GUID]"]
         remove_field => ["[cloudwatch_logs][tags][ServiceGUID]"]
+        remove_field => ["[cloudwatch_logs][tags][Service GUID]"]
     }
     truncate {
       fields => ["message"]

--- a/jobs/ingestor_cloudwatch/templates/config/input_and_output.conf.erb
+++ b/jobs/ingestor_cloudwatch/templates/config/input_and_output.conf.erb
@@ -47,7 +47,7 @@ filter
         remove_field => ["[cloudwatch_logs][tags][Createdat]"]
         remove_field => ["[cloudwatch_logs][tags][Created at]"]
         remove_field => ["[cloudwatch_logs][tags][Updatedat]"]
-        remove_field => ["[cloudwatch_logs][tags][Updateda t]"]
+        remove_field => ["[cloudwatch_logs][tags][Updated at]"]
         remove_field => ["[cloudwatch_logs][tags][client]"]
         remove_field => ["[cloudwatch_logs][tags][PlanGUID]"]
         remove_field => ["[cloudwatch_logs][tags][Plan GUID]"]

--- a/jobs/opensearch_templates/templates/component-index-mappings-app.json.erb
+++ b/jobs/opensearch_templates/templates/component-index-mappings-app.json.erb
@@ -29,6 +29,7 @@ keyword_default = { "type": "keyword", "index": true }.to_json
             "process_id":     <%= keyword_default %>,
             "process_instance_id": <%= keyword_default %>,
             "process_type":  <%= keyword_default %>,
+            "service": <%= keyword_default %>,
             "service_offering": <%= keyword_default %>,
             "service_plan": <%= keyword_default %>
           }


### PR DESCRIPTION
Related to https://github.com/cloud-gov/opensearch-boshrelease/issues/144

## Changes proposed in this pull request:

- update logstash filters for ingestor_cloudwatch to map tag names with spaces
- add mapping for Instance name tag
- add index mapping for `@cf.service` field

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just updating Logstash filters to accept field names with or without spaces
