### PR TITLE
Add mappings for cloudwatch tag names with spaces

### DIFF
--- a/jobs/ingestor_cloudwatch/templates/config/input_and_output.conf.erb
+++ b/jobs/ingestor_cloudwatch/templates/config/input_and_output.conf.erb
@@ -34,12 +34,14 @@ filter
         rename => {"[cloudwatch_logs][tags][InstanceGUID]"=>"[@cf][service_instance_id]"}
         rename => {"[cloudwatch_logs][tags][Instance GUID]"=>"[@cf][service_instance_id]"}
 
+        rename => {"[cloudwatch_logs][tags][Instancename]"=>"[@cf][service]"}
         rename => {"[cloudwatch_logs][tags][Instance name]"=>"[@cf][service]"}
 
         rename => {"[cloudwatch_logs][tags][Serviceofferingname]"=>"[@cf][service_offering]"}
         rename => {"[cloudwatch_logs][tags][Service offering name]"=>"[@cf][service_offering]"}
 
         rename => {"[cloudwatch_logs][tags][Service plan name]"=>"[@cf][service_plan]"}
+        rename => {"[cloudwatch_logs][tags][Serviceplanname]"=>"[@cf][service_plan]"}
 
         rename => {"[cloudwatch_logs][tags][service]"=>"broker"}
         rename => {"[cloudwatch_logs][tags][broker]"=>"broker"}


### PR DESCRIPTION
## Changes proposed in this pull request:

Related to https://github.com/cloud-gov/opensearch-boshrelease/issues/144

-  Add mappings for cloudwatch tag names with spaces so fields get mapped properly

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None. These changes are not sensitive and merely provide additional mappings between incoming data and index fields
