### PR TITLE
Lowering refresh interval to lower overhead and increasing threshold …

### DIFF
--- a/jobs/upload_opensearch_config/templates/index-templates/index-settings.json.erb
+++ b/jobs/upload_opensearch_config/templates/index-templates/index-settings.json.erb
@@ -2,6 +2,9 @@
   "template": {
     "settings": {
       "index": {
+        "translog": {
+            "flush_threshold_size": "1024MB"
+        },
         "codec": "best_compression",
         "search": {
           "slowlog": {

--- a/jobs/upload_opensearch_config/templates/index-templates/shards-and-replicas.json.erb
+++ b/jobs/upload_opensearch_config/templates/index-templates/shards-and-replicas.json.erb
@@ -3,7 +3,8 @@
     "settings": {
       "number_of_shards": <%= p('opensearch_config.shard_count')%>,
       "number_of_replicas" : 1,
-      "plugins.index_state_management.rollover_alias": "<%= p('opensearch_config.alias')%>"
+      "plugins.index_state_management.rollover_alias": "<%= p('opensearch_config.alias')%>",
+      "refresh_interval": "2s"
     }
   }
 }


### PR DESCRIPTION
…to match ram and lower segments to reorganize

## Changes proposed in this pull request:
- Change threshold to 1024 instead of 512, this will cut the amount of segments in half and is the recommended size for our ram amount.
- change refresh interval to 2s which gives more time for full flushes before refresh making less segments
-

## Security considerations

None
