### PR TITLE
setting limit higher to match watermark level

### DIFF
--- a/jobs/opensearch/monit
+++ b/jobs/opensearch/monit
@@ -8,4 +8,4 @@ check device os-ephemeral_disk with path /var/vcap/data
   if SPACE usage > 80% then alert
 
 check device os-persistent_disk with path /var/vcap/store
-  if SPACE usage > 80% then alert
+  if SPACE usage > 87% then alert

--- a/jobs/opensearch/monit
+++ b/jobs/opensearch/monit
@@ -8,4 +8,4 @@ check device os-ephemeral_disk with path /var/vcap/data
   if SPACE usage > 80% then alert
 
 check device os-persistent_disk with path /var/vcap/store
-  if SPACE usage > 87% then alert
+  if SPACE usage > 85% then alert


### PR DESCRIPTION
## Changes proposed in this pull request:
- limit for persistant is too low, 87 is our watermark low which is when opensearch will worry
-
-


## Security considerations
None
