### PR TITLE
fix path to SSL cert files in ingestor_syslog script

### DIFF
--- a/jobs/ingestor_syslog/templates/bin/ingestor_syslog
+++ b/jobs/ingestor_syslog/templates/bin/ingestor_syslog
@@ -8,7 +8,7 @@ set -u # report the usage of uninitialized variables
 JOB_NAME=ingestor_syslog
 export LOG_DIR=/var/vcap/sys/log/$JOB_NAME
 export STORE_DIR=/var/vcap/store/$JOB_NAME
-export JOB_DIR=/var/vcap/jobs/$JOB_NAME
+export JOB_DIR=/$JOB_NAME
 source /var/vcap/packages/openjdk-17/bosh/runtime.env
 
 <%
@@ -27,9 +27,9 @@ function wait_for_template {
   while true;  do
     echo "Waiting for index template to be uploaded: $template_name"
     curl \
-    --key ${JOB_DIR}/ssl/ingestor.key \
-    --cert ${JOB_DIR}/ssl/ingestor.crt  \
-    --cacert ${JOB_DIR}/ssl/opensearch.ca \
+    --key ${JOB_DIR}/config/ssl/ingestor.key \
+    --cert ${JOB_DIR}/config/ssl/ingestor.crt  \
+    --cacert ${JOB_DIR}/config/ssl/opensearch.ca \
     -I -f -i "$MASTER_URL"/_template/$template_name > /dev/null 2>&1
     [ $? ] && break
     sleep 5


### PR DESCRIPTION
## Changes proposed in this pull request:

- fix path to SSL cert files in ingestor_syslog script

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None. Nothing about TLS security is changing, just fixing a script to reference the proper file paths for TLS certificates
