### PR TITLE
update CF auth proxy to version 0.0.8

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -174,10 +174,10 @@ opensearch-dashboards-3.1.0-linux-x64.tar.gz:
   size: 385456866
   object_id: 7444b652-d178-4b48-6632-12ccd4a3dd8a
   sha: sha256:d7ae01dce54d13a62cc268dfede9941331805270073cb5e3832aa8fc54c4156f
-opensearch-dashboards-cf-auth-proxy-0.0.7.tar.gz:
-  size: 35056
-  object_id: ea4bbc49-356f-4935-696f-b00ec3da6e6e
-  sha: sha256:c73877ea46ceb878877afb01ce9ef73a4edd81a6356867250c00e78752d8c35a
+opensearch-dashboards-cf-auth-proxy-0.0.8.tar.gz:
+  size: 35751
+  object_id: 5ab0f5e3-60bc-4171-688e-aa912d6e94d5
+  sha: sha256:b02ee8b6e62757817fb4aa4c120f420f86a9c480afd10cec6c70ad43ab9ac9d4
 requests/certifi-2023.11.17-py3-none-any.whl:
   size: 162530
   object_id: f2afff72-e415-4390-61c1-eb8010ed4e4a

--- a/packages/opensearch-dashboards-cf-auth-proxy/packaging
+++ b/packages/opensearch-dashboards-cf-auth-proxy/packaging
@@ -6,4 +6,4 @@ export LD_LIBRARY_PATH="/var/vcap/packages/python3/lib:${LD_LIBRARY_PATH}"
 export C_INCLUDE_PATH="/var/vcap/packages/python3/include:${C_INCLUDE_PATH}"
 
 python3 -m pip install "--prefix=${BOSH_INSTALL_TARGET}" --no-index auth-proxy/*.whl
-tar xzvf opensearch-dashboards-cf-auth-proxy-0.0.7.tar.gz -C $BOSH_INSTALL_TARGET --strip-components 1
+tar xzvf opensearch-dashboards-cf-auth-proxy-0.0.8.tar.gz -C $BOSH_INSTALL_TARGET --strip-components 1

--- a/packages/opensearch-dashboards-cf-auth-proxy/spec
+++ b/packages/opensearch-dashboards-cf-auth-proxy/spec
@@ -15,5 +15,5 @@ dependencies:
     - python3
 
 files:
-    - opensearch-dashboards-cf-auth-proxy-0.0.7.tar.gz
+    - opensearch-dashboards-cf-auth-proxy-0.0.8.tar.gz
     - auth-proxy/*


### PR DESCRIPTION
## Changes proposed in this pull request:

- update CF auth proxy to version 0.0.8

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Includes security fixes from https://github.com/cloud-gov/opensearch-dashboards-cf-auth-proxy/pull/154
