### PR TITLE
add mutate filter to remove escaped hex values in JSON strings, since…

### DIFF
--- a/src/cf-logstash-filters/src/logstash-filters/snippets/app-logmessage-app.conf
+++ b/src/cf-logstash-filters/src/logstash-filters/snippets/app-logmessage-app.conf
@@ -18,6 +18,12 @@ if [@source][type] =~ /APP(|\/.*)$/ {
 
     ## ---- Format 1: JSON
     if [@message] =~ /^\s*{".*}\s*$/ { # if it looks like JSON
+        # Remove hexidecimal encoded values, like "\x22", which break
+        # JSON parsing
+        mutate {
+            gsub => [ "@message", "\\x[0-9a-fA-F]{2}", "" ]
+        }
+
         truncate {
             fields => ["@message"]
             add_tag => [ "_messagetrimmed" ]


### PR DESCRIPTION
… they break JSON parsing by the json logstash filter

## Changes proposed in this pull request:

-
-
-

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

[Note the any security considerations here, or make note of why there are none]
