### PR TITLE
give users with cf_user role access to metric indexes

### DIFF
--- a/jobs/opensearch/templates/config/opensearch-security/roles.yml.erb
+++ b/jobs/opensearch/templates/config/opensearch-security/roles.yml.erb
@@ -373,6 +373,7 @@ cf_user:
   index_permissions:
   - index_patterns:
     - "logs-app-*"
+    - "logs-metrics-*"
     dls: "{\"bool\": {\"should\": [{\"terms\": { \"@cf.space_id\": [${attr.proxy.spaceids}] }}, {\"terms\": {\"@cf.org_id\": [${attr.proxy.orgids}]}}]}}"
     fls:
     allowed_actions:


### PR DESCRIPTION
## Changes proposed in this pull request:

After https://github.com/cloud-gov/opensearch-boshrelease/pull/213 was merged/deployed, metrics are now stored in a new index pattern, `logs-metrics-*`. However, non-admin users never had their permissions updated to allow reading data from these indexes, so they are unable to view metrics in OpenSearch Dashboards. This PR updates the `cf_user` role for non-admins to give them access to read from the `logs-metrics-*` indexes.

- give users with cf_user role access to read from logs-metrics-* indexes with DLS restrictions applied

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Non-admin users should have read access to data in `logs-metrics-*` to view their application and service metrics. These  read-only permissions are also filtered by the DLS restrictions in the `cf_user` role, so that users can only see metrics for applications/services in their orgs and spaces.
