### PR TITLE
update opensearch job spec to create bin/drain script

### DIFF
--- a/jobs/opensearch/spec
+++ b/jobs/opensearch/spec
@@ -10,6 +10,7 @@ packages:
   - cf-cli-8-linux
 
 templates:
+  bin/drain.erb: bin/drain
   bin/opensearch: bin/opensearch.sh
   bin/pre-start.erb: bin/pre-start
   bin/post-deploy.erb: bin/post-deploy


### PR DESCRIPTION
## Changes proposed in this pull request:

- update opensearch job spec to create bin/drain script so that useful drain behaviors will run when VMs are restarting

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just fixing release to include missing drain script
