### PR TITLE
Update metrics field mappings

### DIFF
--- a/jobs/upload-dashboards-objects/templates/dashboards-objects/index-pattern/logs-metric.json.erb
+++ b/jobs/upload-dashboards-objects/templates/dashboards-objects/index-pattern/logs-metric.json.erb
@@ -1,6 +1,344 @@
+<%
+
+require 'json'
+
+#########################
+## -- Common fields -- ##
+#########################
+fields_json = [
+    {"name":"@cf.org","type":"text","count":0,"scripted":false,"indexed":true,"analyzed":false,"doc_values":true},
+    {"name":"@cf.org_id","type":"text","count":0,"scripted":false,"indexed":true,"analyzed":false,"doc_values":true},
+    {"name":"@cf.space","type":"text","count":0,"scripted":false,"indexed":true,"analyzed":false,"doc_values":true},
+    {"name":"@cf.space_id","type":"text","count":0,"scripted":false,"indexed":true,"analyzed":false,"doc_values":true},
+    {"name":"@cf.app","type":"text","count":0,"scripted":false,"indexed":true,"analyzed":false,"doc_values":true},
+    {"name":"@cf.app_id","type":"text","count":0,"scripted":false,"indexed":true,"analyzed":false,"doc_values":true},
+    {"name":"@cf.app_instance","type":"number","count":0,"scripted":false,"indexed":true,"analyzed":false,"doc_values":true},
+    {"name":"@cf.process_id","type":"number","count":0,"scripted":false,"indexed":true,"analyzed":false,"doc_values":true},
+    {"name":"@cf.process_instance_id","type":"number","count":0,"scripted":false,"indexed":true,"analyzed":false,"doc_values":true},
+    {"name":"@cf.process_type","type":"number","count":0,"scripted":false,"indexed":true,"analyzed":false,"doc_values":true},
+    {
+        "count": 0,
+        "name": "@index_type",
+        "type": "string",
+        "esTypes": [
+            "match_only_text"
+        ],
+        "scripted": false,
+        "searchable": true,
+        "aggregatable": false,
+        "readFromDocValues": false
+    },
+    {
+        "count": 0,
+        "name": "@input",
+        "type": "string",
+        "esTypes": [
+            "match_only_text"
+        ],
+        "scripted": false,
+        "searchable": true,
+        "aggregatable": false,
+        "readFromDocValues": false
+    },
+    {
+        "count": 0,
+        "name": "@level",
+        "type": "string",
+        "esTypes": [
+            "match_only_text"
+        ],
+        "scripted": false,
+        "searchable": true,
+        "aggregatable": false,
+        "readFromDocValues": false
+    },
+    {
+        "count": 0,
+        "name": "@raw",
+        "type": "string",
+        "esTypes": [
+            "keyword"
+        ],
+        "scripted": false,
+        "searchable": true,
+        "aggregatable": true,
+        "readFromDocValues": true
+    },
+    {
+        "count": 0,
+        "name": "@shipper",
+        "type": "unknown",
+        "esTypes": [
+            "flat_object"
+        ],
+        "scripted": false,
+        "searchable": true,
+        "aggregatable": false,
+        "readFromDocValues": false
+    },
+    {
+        "count": 0,
+        "name": "@source",
+        "type": "unknown",
+        "esTypes": [
+            "flat_object"
+        ],
+        "scripted": false,
+        "searchable": true,
+        "aggregatable": false,
+        "readFromDocValues": false
+    },
+    {
+        "count": 0,
+        "name": "@timestamp",
+        "type": "date",
+        "esTypes": [
+            "date"
+        ],
+        "scripted": false,
+        "searchable": true,
+        "aggregatable": true,
+        "readFromDocValues": true
+    },
+    {
+        "count": 0,
+        "name": "@type",
+        "type": "string",
+        "esTypes": [
+            "match_only_text"
+        ],
+        "scripted": false,
+        "searchable": true,
+        "aggregatable": false,
+        "readFromDocValues": false
+    },
+    {
+        "count": 0,
+        "name": "@version",
+        "type": "string",
+        "esTypes": [
+            "keyword"
+        ],
+        "scripted": false,
+        "searchable": true,
+        "aggregatable": true,
+        "readFromDocValues": true
+    },
+    {
+        "count": 0,
+        "name": "_id",
+        "type": "string",
+        "esTypes": [
+            "_id"
+        ],
+        "scripted": false,
+        "searchable": true,
+        "aggregatable": true,
+        "readFromDocValues": false
+    },
+    {
+        "count": 0,
+        "name": "_index",
+        "type": "string",
+        "esTypes": [
+            "_index"
+        ],
+        "scripted": false,
+        "searchable": true,
+        "aggregatable": true,
+        "readFromDocValues": false
+    },
+    {
+        "count": 0,
+        "name": "_score",
+        "type": "number",
+        "scripted": false,
+        "searchable": false,
+        "aggregatable": false,
+        "readFromDocValues": false
+    },
+    {
+        "count": 0,
+        "name": "_source",
+        "type": "_source",
+        "esTypes": [
+            "_source"
+        ],
+        "scripted": false,
+        "searchable": false,
+        "aggregatable": false,
+        "readFromDocValues": false
+    },
+    {
+        "count": 0,
+        "name": "_type",
+        "type": "string",
+        "scripted": false,
+        "searchable": false,
+        "aggregatable": false,
+        "readFromDocValues": false
+    },
+    {
+        "count": 0,
+        "name": "app",
+        "type": "unknown",
+        "esTypes": [
+            "flat_object"
+        ],
+        "scripted": false,
+        "searchable": true,
+        "aggregatable": false,
+        "readFromDocValues": false
+    },
+    {
+        "count": 0,
+        "name": "containermetric.cpu_percentage",
+        "type": "number",
+        "esTypes": [
+            "half_float"
+        ],
+        "scripted": false,
+        "searchable": true,
+        "aggregatable": true,
+        "readFromDocValues": true
+    },
+    {
+        "count": 0,
+        "name": "containermetric.disk_bytes",
+        "type": "number",
+        "esTypes": [
+            "long"
+        ],
+        "scripted": false,
+        "searchable": true,
+        "aggregatable": true,
+        "readFromDocValues": true
+    },
+    {
+        "count": 0,
+        "name": "containermetric.disk_bytes_quota",
+        "type": "number",
+        "esTypes": [
+            "long"
+        ],
+        "scripted": false,
+        "searchable": true,
+        "aggregatable": true,
+        "readFromDocValues": true
+    },
+    {
+        "count": 0,
+        "name": "containermetric.memory_bytes",
+        "type": "number",
+        "esTypes": [
+            "long"
+        ],
+        "scripted": false,
+        "searchable": true,
+        "aggregatable": true,
+        "readFromDocValues": true
+    },
+    {
+        "count": 0,
+        "name": "containermetric.memory_bytes_quota",
+        "type": "number",
+        "esTypes": [
+            "long"
+        ],
+        "scripted": false,
+        "searchable": true,
+        "aggregatable": true,
+        "readFromDocValues": true
+    },
+    {
+        "count": 0,
+        "name": "containermetric.name",
+        "type": "string",
+        "esTypes": [
+            "text"
+        ],
+        "scripted": false,
+        "searchable": true,
+        "aggregatable": false,
+        "readFromDocValues": false
+    },
+    {
+        "count": 0,
+        "name": "containermetric.unit",
+        "type": "string",
+        "esTypes": [
+            "text"
+        ],
+        "scripted": false,
+        "searchable": true,
+        "aggregatable": false,
+        "readFromDocValues": false
+    },
+    {
+        "count": 0,
+        "name": "containermetric.value",
+        "type": "string",
+        "esTypes": [
+            "text"
+        ],
+        "scripted": false,
+        "searchable": true,
+        "aggregatable": false,
+        "readFromDocValues": false
+    },
+    {
+        "count": 0,
+        "name": "geoip.location",
+        "type": "geo_point",
+        "esTypes": [
+            "geo_point"
+        ],
+        "scripted": false,
+        "searchable": true,
+        "aggregatable": true,
+        "readFromDocValues": true
+    },
+    {
+        "count": 0,
+        "name": "metrics_sd_params",
+        "type": "unknown",
+        "esTypes": [
+            "flat_object"
+        ],
+        "scripted": false,
+        "searchable": true,
+        "aggregatable": false,
+        "readFromDocValues": false
+    },
+    {
+        "count": 0,
+        "name": "syslog_sd_params",
+        "type": "unknown",
+        "esTypes": [
+            "flat_object"
+        ],
+        "scripted": false,
+        "searchable": true,
+        "aggregatable": false,
+        "readFromDocValues": false
+    },
+    {
+        "count": 0,
+        "name": "tags",
+        "type": "string",
+        "esTypes": [
+            "keyword"
+        ],
+        "scripted": false,
+        "searchable": true,
+        "aggregatable": true,
+        "readFromDocValues": true
+    }
+]
+%>
 {
     "attributes": {
-        "fields": "[{\"count\":0,\"name\":\"@cf.app\",\"type\":\"string\",\"esTypes\":[\"keyword\"],\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"@cf.app_id\",\"type\":\"string\",\"esTypes\":[\"match_only_text\"],\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"@cf.app_instance\",\"type\":\"string\",\"esTypes\":[\"keyword\"],\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"@cf.org\",\"type\":\"string\",\"esTypes\":[\"keyword\"],\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"@cf.org_id\",\"type\":\"string\",\"esTypes\":[\"match_only_text\"],\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"@cf.process_id\",\"type\":\"string\",\"esTypes\":[\"match_only_text\"],\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"@cf.process_instance_id\",\"type\":\"string\",\"esTypes\":[\"match_only_text\"],\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"@cf.process_type\",\"type\":\"string\",\"esTypes\":[\"match_only_text\"],\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"@cf.space\",\"type\":\"string\",\"esTypes\":[\"keyword\"],\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"@cf.space_id\",\"type\":\"string\",\"esTypes\":[\"match_only_text\"],\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"@index_type\",\"type\":\"string\",\"esTypes\":[\"match_only_text\"],\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"@input\",\"type\":\"string\",\"esTypes\":[\"match_only_text\"],\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"@level\",\"type\":\"string\",\"esTypes\":[\"match_only_text\"],\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"@raw\",\"type\":\"string\",\"esTypes\":[\"keyword\"],\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"@shipper\",\"type\":\"unknown\",\"esTypes\":[\"flat_object\"],\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"@source\",\"type\":\"unknown\",\"esTypes\":[\"flat_object\"],\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"@timestamp\",\"type\":\"date\",\"esTypes\":[\"date\"],\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"@type\",\"type\":\"string\",\"esTypes\":[\"match_only_text\"],\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"@version\",\"type\":\"string\",\"esTypes\":[\"keyword\"],\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"_id\",\"type\":\"string\",\"esTypes\":[\"_id\"],\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":false},{\"count\":0,\"name\":\"_index\",\"type\":\"string\",\"esTypes\":[\"_index\"],\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":false},{\"count\":0,\"name\":\"_score\",\"type\":\"number\",\"scripted\":false,\"searchable\":false,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"_source\",\"type\":\"_source\",\"esTypes\":[\"_source\"],\"scripted\":false,\"searchable\":false,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"_type\",\"type\":\"string\",\"scripted\":false,\"searchable\":false,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"app\",\"type\":\"unknown\",\"esTypes\":[\"flat_object\"],\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"containermetric.cpu_percentage\",\"type\":\"number\",\"esTypes\":[\"half_float\"],\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"containermetric.disk_bytes\",\"type\":\"number\",\"esTypes\":[\"long\"],\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"containermetric.disk_bytes_quota\",\"type\":\"number\",\"esTypes\":[\"long\"],\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"containermetric.memory_bytes\",\"type\":\"number\",\"esTypes\":[\"long\"],\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"containermetric.memory_bytes_quota\",\"type\":\"number\",\"esTypes\":[\"long\"],\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"containermetric.name\",\"type\":\"string\",\"esTypes\":[\"text\"],\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"containermetric.unit\",\"type\":\"string\",\"esTypes\":[\"text\"],\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"containermetric.value\",\"type\":\"string\",\"esTypes\":[\"text\"],\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"geoip.location\",\"type\":\"geo_point\",\"esTypes\":[\"geo_point\"],\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"metrics_sd_params\",\"type\":\"unknown\",\"esTypes\":[\"flat_object\"],\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"syslog_sd_params\",\"type\":\"unknown\",\"esTypes\":[\"flat_object\"],\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"tags\",\"type\":\"string\",\"esTypes\":[\"keyword\"],\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true}]",
+        "fields": "<%= fields_json.to_json.gsub(/\\/, '\\\\').gsub(/"/, '\"') %>"
         "timeFieldName": "@timestamp",
         "title": "logs-metrics-*"
     },


### PR DESCRIPTION
## Changes proposed in this pull request:

[The cf_user role was updated to allow search the contents of logs-metrics-* index pattern](https://github.com/cloud-gov/opensearch-boshrelease/pull/221). However, the DLS query enforced by the role seems incompatible with the `match_only_text` field mappings. 

This PR updates the field mappings for `@cf` fields from `match_only_text` to `text`, which matches the implementation on the `logs-app-*` index pattern where DLS queries work.

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Non-admin users should be able to search the logs-metrics-* indexes and see their metrics. These updates ensure that the DLS query on the cf_user role will work correctly to show users only their metrics.
