### PR TITLE
Need to always give a 0

### DIFF
--- a/jobs/opensearch/templates/bin/drain.erb
+++ b/jobs/opensearch/templates/bin/drain.erb
@@ -26,6 +26,4 @@ curl -X DELETE -s https://localhost:9200/_snapshot/<%= p('opensearch.repository.
 curl -X DELETE -s https://localhost:9200/_snapshot/<%= p('opensearch.repository.name') %> > /dev/null
 <% end %>
 
-return_code=$?
-echo 0
-exit ${return_code}
+exit 0

--- a/jobs/opensearch/templates/bin/drain.erb
+++ b/jobs/opensearch/templates/bin/drain.erb
@@ -25,5 +25,3 @@ curl -X DELETE -s https://localhost:9200/_snapshot/<%= p('opensearch.repository.
 <% if p('opensearch.path_repo') != '' and p('opensearch.node.allow_cluster_manager') and spec.bootstrap %>
 curl -X DELETE -s https://localhost:9200/_snapshot/<%= p('opensearch.repository.name') %> > /dev/null
 <% end %>
-
-exit 0


### PR DESCRIPTION
## Changes proposed in this pull request:\
- The drain script does a curl with no return, there is no case to return on so should always be 0
-
-

## Security considerations
None
