### PR TITLE
Refactor logstash filters

### DIFF
--- a/src/cf-logstash-filters/src/logstash-filters/cloudwatch.conf.erb
+++ b/src/cf-logstash-filters/src/logstash-filters/cloudwatch.conf.erb
@@ -1,3 +1,6 @@
+# This file contains the filters for parsing CF tags into fields
+<%= File.read('src/logstash-filters/snippets/cf-tags.conf') %>
+
 # This file contains the filters for cloudwatch from s3
 <%= File.read('src/logstash-filters/snippets/cloudwatch.conf') %>
 

--- a/src/cf-logstash-filters/src/logstash-filters/metrics.conf.erb
+++ b/src/cf-logstash-filters/src/logstash-filters/metrics.conf.erb
@@ -1,3 +1,6 @@
+# This file contains the filters for parsing CF tags into fields
+<%= File.read('src/logstash-filters/snippets/cf-tags.conf') %>
+
 # This file contains the filters for metrics from s3
 <%= File.read('src/logstash-filters/snippets/metrics.conf') %>
 

--- a/src/cf-logstash-filters/src/logstash-filters/snippets/cf-tags.conf
+++ b/src/cf-logstash-filters/src/logstash-filters/snippets/cf-tags.conf
@@ -1,0 +1,22 @@
+mutate
+{
+rename => {"[Tags][Created at]" => "[created at]"}
+rename => {"[Tags][Updated at]" => "[updated at]"}
+rename => {"[Tags][Organization GUID]"=>"[@cf][org_id]"}
+rename => {"[Tags][Organization name]"=>"[@cf][org]"}
+rename => {"[Tags][Space GUID]"=>"[@cf][space_id]"}
+rename => {"[Tags][Space name]"=>"[@cf][space]"}
+rename => {"[Tags][Service plan name]"=>"[@cf][service_plan]"}
+rename => {"[Tags][Plan GUID]"=>"[@cf][plan_id]"}
+rename => {"[Tags][Service offering name]"=>"[@cf][service_offering]"}
+rename => {"[Tags][Instance GUID]"=>"[@cf][instance_id]"}
+rename => {"[Tags][Instance name]"=>"[@cf][instance]"}
+rename => {"[Tags][broker]"=>"[broker]"}
+remove_field => [
+  "[Tags][client]",
+  "[Tags][Service GUID]",
+  "[Tags][service]",
+  "[Tags][environment]",
+  "timestamp"
+]
+}

--- a/src/cf-logstash-filters/src/logstash-filters/snippets/cloudwatch.conf
+++ b/src/cf-logstash-filters/src/logstash-filters/snippets/cloudwatch.conf
@@ -19,24 +19,10 @@ if [logGroup] =~ "^/aws/rds/instance/" {
 mutate
 {
 add_field => {"@type" => "cloudwatch"}
-rename => {"[Tags][Created at]" => "[created at]"}
-rename => {"[Tags][Updated at]" => "[updated at]"}
-rename => {"[Tags][Organization GUID]"=>"[@cf][org_id]"}
-rename => {"[Tags][Organization name]"=>"[@cf][org]"}
-rename => {"[Tags][Space GUID]"=>"[@cf][space_id]"}
-rename => {"[Tags][Space name]"=>"[@cf][space]"}
-rename => {"[Tags][Service plan name]"=>"[@cf][service_plan]"}
-rename => {"[Tags][Plan GUID]"=>"[@cf][plan_id]"}
-rename => {"[Tags][Service GUID]"=>"[@cf][service_instance_id]"}
-rename => {"[Tags][service]"=>"[@cf][service]"}
-rename => {"[Tags][Service offering name]"=>"[@cf][service_offering]"}
-rename => {"[Tags][Instance GUID]"=>"[@cf][instance_id]"}
-rename => {"[Tags][Instance name]"=>"[@cf][instance]"}
-rename => {"[Tags][broker]"=>"[broker]"}
-rename => {"[Tags][environment]"=>"environment"}
+
 rename => {"message"=>"@message"}
 rename => {"logGroup"=>"[cloudwatch_logs][log_group]"}
 rename => {"logStream"=>"[cloudwatch_logs][log_stream]"}
-remove_field => ["[Tags][client]","timestamp","environment"]
+
 }
 

--- a/src/cf-logstash-filters/src/logstash-filters/snippets/metrics.conf
+++ b/src/cf-logstash-filters/src/logstash-filters/snippets/metrics.conf
@@ -19,22 +19,7 @@ target => "@timestamp"
 mutate
 {
 add_field => {"@type" => "metrics"}
-rename => {"[Tags][Organization GUID]"=>"[@cf][org_id]"}
-rename => {"[Tags][Organization name]"=>"[@cf][org]"}
-rename => {"[Tags][Space GUID]"=>"[@cf][space_id]"}
-rename => {"[Tags][Space name]"=>"[@cf][space]"}
-rename => {"[Tags][Service plan name]"=>"[@cf][service_plan]"}
-rename => {"[Tags][Plan GUID]"=>"[@cf][plan_id]"}
-rename => {"[Tags][Service GUID]"=>"[@cf][service_instance_id]"}
-rename => {"[Tags][service]"=>"[@cf][service]"}
-rename => {"[Tags][Service offering name]"=>"[@cf][service_offering]"}
-rename => {"[Tags][Instance GUID]"=>"[@cf][instance_id]"}
-rename => {"[Tags][Instance name]"=>"[@cf][instance]"}
 
-rename => {"[Tags][Created at]" => "[created at]"}
-rename => {"[Tags][Updated at]" => "[updated at]"}
-rename => {"[Tags][broker]"=>"[broker]"}
-rename => {"[Tags][environment]"=>"environment"}
 rename => {"[Tags][db_size]"=>"[metric][db_size]"}
 rename => {"[dimensions][NodeId]"=>"[metric][node_id]"}
 rename => {"[dimensions][StorageType]"=>"[metric][storage_type]"}
@@ -52,10 +37,8 @@ rename => {"[Tags][DomainName]"=>"[metric][domain_name]"}
 rename => {"[Average]"=>"[metric][average]"}
 rename => {"[unit]"=>"[metric][unit]"}
 rename => {"[Unit]"=>"[metric][unit]"}
-remove_field => ["[Tags][client]"]
 
-
-remove_field => ["[Tags][client]","timestamp","environment","[dimensions][BucketName]"]
+remove_field => ["[dimensions][BucketName]"]
 }
 
 ruby {


### PR DESCRIPTION
## Changes proposed in this pull request:

- refactor logstash filters to re-use CF tag filters defined once in a reusable snippet
- Drop mappings for:
  - `@cf.service`: This seems to contain the name of the broker (e.g. `AWS broker`) and is redundant with `broker`
  - `@cf.service_instance_id`: Despite the name, this field did not actually contain the ID of the service instance. Rather, it was the internal ID of the brokered service within its own catalog. This ID is not something that relates to any actual platform resources, therefore it is not useful to users


## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None. Just refactoring how data is parsed for ingested logs
