### PR TITLE
Re-enable alerting and notifications plugins

### DIFF
--- a/jobs/opensearch/templates/config/config.yml.erb
+++ b/jobs/opensearch/templates/config/config.yml.erb
@@ -112,3 +112,7 @@ cluster.routing.allocation.disk.watermark.high: <%= high %>
 <% if_p('opensearch.routing.watermark.flood_stage') do |flood_stage| %>
 cluster.routing.allocation.disk.watermark.flood_stage: <%= flood_stage %>
 <% end %>
+
+plugins.alerting.filter_by_backend_roles: true
+opensearch.notifications.general.filter_by_backend_roles: true
+plugins.security.user_attribute_serialization.enabled: true

--- a/packages/opensearch/packaging
+++ b/packages/opensearch/packaging
@@ -8,3 +8,6 @@ export PATH="${BOSH_INSTALL_TARGET}/bin:${PATH}"
 opensearch-plugin remove opensearch-notifications
 opensearch-plugin remove opensearch-security-analytics
 opensearch-plugin remove opensearch-alerting
+
+echo y | opensearch-plugin install "file://${PWD}/opensearch/opensearch-notifications-3.3.1.0.zip"
+echo y | opensearch-plugin install "file://${PWD}/opensearch/opensearch-alerting-3.3.1.0.zip"

--- a/packages/opensearchDashboards/packaging
+++ b/packages/opensearchDashboards/packaging
@@ -13,7 +13,3 @@ opensearch-dashboards-plugin remove queryInsightsDashboards --allow-root
 opensearch-dashboards-plugin remove queryWorkbenchDashboards --allow-root
 opensearch-dashboards-plugin remove searchRelevanceDashboards --allow-root
 opensearch-dashboards-plugin remove securityAnalyticsDashboards --allow-root
-
-# Removes alerting and notification
-opensearch-dashboards-plugin remove alertingDashboards --allow-root
-opensearch-dashboards-plugin remove notificationsDashboards --allow-root


### PR DESCRIPTION
## Changes proposed in this pull request:

- Re-enable alerting and notifications plugins

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Enabling the plugins should have no direct security implications. Access to the objects created with the plugins are managed with `filter_by_backend_roles`, which enforces that only users with **all of the same backend roles** can see each other's objects.
