### PR TITLE
re-add keystore credentials script

### DIFF
--- a/jobs/opensearch/spec
+++ b/jobs/opensearch/spec
@@ -17,6 +17,7 @@ templates:
   bin/pre-start.erb: bin/pre-start
   bin/post-deploy.erb: bin/post-deploy
   bin/post-start.erb: bin/post-start
+  bin/add-keystore-credentials.sh.erb: bin/add-keystore-credentials.sh
   config/bpm.yml.erb: config/bpm.yml
   config/config.yml.erb: config/opensearch.yml
   config/ca.erb: config/ssl/opensearch.ca

--- a/jobs/opensearch/templates/bin/post-start.erb
+++ b/jobs/opensearch/templates/bin/post-start.erb
@@ -98,3 +98,6 @@ echo "Disable post start script property is set to <%= p("opensearch.health.disa
     -icl -nhnv
   <% end %>
 <% end %>
+
+# Add credentials to keystore
+$JOB_DIR/bin/add-keystore-credentials.sh


### PR DESCRIPTION
## Changes proposed in this pull request:

- re-add keystore credentials script
-
-

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Script is used to securely add credentials to the OpenSearch keystore
