### PR TITLE
removing secondary json filter

### DIFF
--- a/src/cf-logstash-filters/src/logstash-filters/snippets/app-logmessage-app.conf
+++ b/src/cf-logstash-filters/src/logstash-filters/snippets/app-logmessage-app.conf
@@ -25,8 +25,9 @@ if [@source][type] =~ /APP(|\/.*)$/ {
                 source => "@message"
                 target => "app"
                 id => "cloudfoundry/app-message/json"
+                tag_on_failure => "json_parsing_failed"
             }
-            if !("_jsonparsefailure" in [tags]) {
+            if !("json_parsing_failed" in [tags]) {
                 if [app][message] {
                     mutate {
                         rename => { "[app][message]" => "@message" }
@@ -72,7 +73,7 @@ if [@source][type] =~ /APP(|\/.*)$/ {
             } else {
                 mutate {
                     add_tag => [ "unknown_msg_format" ]
-                    remove_tag => ["_jsonparsefailure"]
+                    remove_tag => ["json_parsing_failed"]
                 }
             }
         }
@@ -89,92 +90,9 @@ if [@source][type] =~ /APP(|\/.*)$/ {
         mutate {
             rename => { "app_logger" => "[app][logger]" }
         }
-    }
-    ## ---- Format 3: Extract JSON from mixed content
-    else {
-        grok {
-            match => {
-                "@message" => [
-                    ".*?(?<json_content>\{.*\}).*?$",  # JSON object anywhere in line
-                    ".*?(?<json_content>\[.*\]).*?$"   # JSON array anywhere in line
-                ]
-            }
-        }
-
-        # If we found JSON content
-        if [json_content] {
-            # Check if it actually starts with { or [
-            if [json_content] =~ /^[\{\[]/ {
-                mutate {
-                    replace => { "new_json" => "%{json_content}" }
-                }
-
-                truncate {
-                    fields => ["new_json"]
-                    add_tag => [ "_messagetrimmed" ]
-                    length_bytes => 32765
-                }
-
-                if !("_messagetrimmed" in [tags]) {
-                    json {
-                        source => "new_json"
-                        target => "app"
-                        id => "cloudfoundry/app-message-misformed/json"
-                    }
-
-                    if !("_jsonparsefailure" in [tags]) {
-
-                        # concat message and exception
-                        if [app][exception] {
-                            mutate {
-                                ## NOTE: keep line break and new line spacing (new line is inserted in logstash in such a way)
-                                replace => { "@message" => "%{@message}\n%{[app][exception]}" }
-                                remove_field => [ "[app][exception]" ]
-                            }
-                        }
-
-                        mutate {
-                            rename => { "[app][level]" => "@level" } # @level
-                        }
-
-                        mutate {
-                            # Top-level fields to http.request
-                            rename => { "[app][bytes_read]" => "[http][request][bytes_read]" }
-                            rename => { "[app][user_id]" => "[http][request][user_id]" }
-                            rename => { "[app][duration]" => "[http][request][duration]" }
-                            rename => { "[app][size]" => "[http][request][size]" }
-                            rename => { "[app][status]" => "[http][request][status]" }
-
-                            # Request object fields to http.request
-                            rename => { "[app][request][remote_ip]" => "[http][request][remote_ip]" }
-                            rename => { "[app][request][remote_port]" => "[http][request][remote_port]" }
-                            rename => { "[app][request][client_ip]" => "[http][request][client_ip]" }
-                            rename => { "[app][request][proto]" => "[http][request][proto]" }
-                            rename => { "[app][request][method]" => "[http][request][method]" }
-                            rename => { "[app][request][host]" => "[http][request][host]" }
-                            rename => { "[app][request][uri]" => "[http][request][uri]" }
-                            rename => { "[app][request][headers]" => "[http][request][headers]" }
-
-                            # Response headers to http.response
-                            rename => { "[app][resp_headers]" => "[http][response][headers]" }
-                        }
-                    } else {
-                        mutate {
-                            add_tag => [ "unknown_msg_format" ]
-                            remove_tag => ["_jsonparsefailure"]
-                        }
-                    }
-                }
-            }
-
-            mutate {
-                remove_field => ["json_content","new_json"]
-            }
-
-        } else {
+    } else {
             mutate {
                 add_tag => [ "unknown_msg_format" ]
             }
-        }
     }
 }


### PR DESCRIPTION
## Changes proposed in this pull request:
- Tag on failure for logs that are marked json but are not (made different name for better conention)
- Removed secondary json
-

## Security considerations
None
