### PR TITLE
add settings for alerting and notification plugins

### DIFF
--- a/jobs/opensearch/templates/config/config.yml.erb
+++ b/jobs/opensearch/templates/config/config.yml.erb
@@ -114,7 +114,11 @@ cluster.routing.allocation.disk.watermark.flood_stage: <%= flood_stage %>
 <% end %>
 
 plugins.alerting.filter_by_backend_roles: true
+plugins.alerting.filter_by_backend_roles_access_strategy: "all"
+
 opensearch.notifications.general.filter_by_backend_roles: true
+opensearch.notifications.general.filter_by_backend_roles_access_strategy: "all"
+
 plugins.security.user_attribute_serialization.enabled: true
 
 plugins.alerting.notification_context_results_allowed_roles: []


### PR DESCRIPTION
## Changes proposed in this pull request:

- add settings for alerting and notification plugins to control filtering by backend roles access strategy

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

These settings control how access to alerting and notification objects is evaluated
