### PR TITLE
Retention better approach

### DIFF
--- a/jobs/upload_opensearch_config/templates/config/ism-policy.json.erb
+++ b/jobs/upload_opensearch_config/templates/config/ism-policy.json.erb
@@ -54,7 +54,7 @@
                 ],
                 "transitions": [
                     {
-                        "state_name": "Shrink_index",
+                        "state_name": "Old_index",
                         "conditions": {
                             "min_index_age": "90d"
                         }
@@ -62,7 +62,7 @@
                 ]
             },
             {
-                "name": "Shrink_index",
+                "name": "Old_index",
                 "actions": [
                     {
                         "retry": {
@@ -70,24 +70,10 @@
                             "backoff": "exponential",
                             "delay": "1m"
                         },
-                        "shrink": {
-                            "num_new_shards": 9,
-                            "force_unsafe": true
+                        "index_settings": {
+                            "index.routing.allocation.total_shards_per_node": "3"
                         }
-                    }
-                ],
-                "transitions": [
-                    {
-                        "state_name": "Old_index",
-                        "conditions": {
-                            "min_index_age": "91d"
-                        }
-                    }
-                ]
-            },
-            {
-                "name": "Old_index",
-                "actions": [
+                    },
                     {
                         "retry": {
                             "count": 3,


### PR DESCRIPTION
## Changes proposed in this pull request:
- shrinking can work as it would allow us to meet the shard size but the complexity is rougher
- change to allow 3 shards per node instead of 2 as we have redundency in snapshots and we do not have write operations, making the nodes only used for search.
-

## Security considerations
None
